### PR TITLE
Implement Iteration 2 Feature: Company Wide WFH Period (Frontend)

### DIFF
--- a/Root/.github/pull_request_template.md
+++ b/Root/.github/pull_request_template.md
@@ -1,12 +1,12 @@
-Closes #32
+Closes #33
 
 ## Dependencies
 
-- Merge PR #31
+- Merge PR #34
 
 ## What does this PR do?
 
-- Allows employees to specify their work location for a selected date and enables team leads/admins to manage or correct entries when necessary
+- Allows Admin to declare a date range as a company-wide “WFH for everyone” period. During this period, employees are treated as WFH by default for reporting and headcount calculations.
 
 ## Type of Change
 
@@ -14,23 +14,25 @@ Closes #32
 
 ## What was changed
 
-- **Employee**
-  - Can set work location per date:
-    - Office
-    - WFH
-  - Can update their own selection before cutoff time (if applicable).
-
-- **Team Lead**
-  - Can view work location of their team members.
-  - Can correct or update missing/incorrect entries within their team.
-
 - **Admin**
-  - Can view and modify work location for any user.
+  - Can define a start date and end date for a WFH period.
+  - Can update or remove an existing WFH period.
+
+- **System Behavior**
+  - During the declared period:
+    - Employees are treated as WFH by default.
+    - Headcount reporting reflects all users as WFH unless explicitly overridden (if allowed).
+    - Meals are opted out
+  - Outside the declared period:
+    - Normal work-location rules apply.
 
 
 ## Changelog
 
-- Feature: Work Location Update 
+
+Feature: Company-wide WFH period
+
+
 
 ## How to Test
 
@@ -39,20 +41,19 @@ Closes #32
 
 ## How QA Should Test
 
-- As an employee change your work location and check status
-- As a team lead change the work location of you team member
-- As an admin change the work location of any employee across all teams
+- Create a WFH period
+- Check employee meal and work status
 
 ## Rollback Plan
 
 - Revert this PR
 
+
 ## Checklist
 
-- [x] All reqirements have been met
+- [x] All requirements have been met
 - [x] All tests pass
-
 
 ## Note for Reviewer
 
-- Frontend has been implemented
+- Frontend has been implemented.

--- a/Root/Task-1/Project/Task 1 Iter 1/Backend/day_controls.json
+++ b/Root/Task-1/Project/Task 1 Iter 1/Backend/day_controls.json
@@ -7,5 +7,30 @@
   {
     "date": "2026-02-22",
     "type": "office_closed"
+  },
+  {
+    "date": "2026-02-24",
+    "type": "COMPANY_WFH",
+    "note": "Khabar nai"
+  },
+  {
+    "date": "2026-02-25",
+    "type": "COMPANY_WFH",
+    "note": "Khabar nai"
+  },
+  {
+    "date": "2026-02-26",
+    "type": "COMPANY_WFH",
+    "note": "Khabar nai"
+  },
+  {
+    "date": "2026-02-27",
+    "type": "COMPANY_WFH",
+    "note": "abc"
+  },
+  {
+    "date": "2026-02-28",
+    "type": "COMPANY_WFH",
+    "note": "abc"
   }
 ]

--- a/Root/Task-1/Project/Task 1 Iter 1/Backend/participation.json
+++ b/Root/Task-1/Project/Task 1 Iter 1/Backend/participation.json
@@ -164,13 +164,7 @@
   {
     "username": "employee101",
     "date": "2026-02-28",
-    "meals": [
-      "Lunch",
-      "Snacks",
-      "Iftar",
-      "Event Dinner",
-      "Optional Dinner"
-    ]
+    "meals": null
   },
   {
     "username": "employee101",
@@ -180,6 +174,106 @@
   {
     "username": "employee101",
     "date": "2026-02-24",
+    "meals": null
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-24",
+    "meals": null
+  },
+  {
+    "username": "teamLead101",
+    "date": "2026-02-24",
+    "meals": null
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-24",
+    "meals": null
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-24",
+    "meals": null
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-25",
+    "meals": null
+  },
+  {
+    "username": "teamLead101",
+    "date": "2026-02-25",
+    "meals": null
+  },
+  {
+    "username": "employee101",
+    "date": "2026-02-25",
+    "meals": null
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-25",
+    "meals": null
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-25",
+    "meals": null
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-26",
+    "meals": null
+  },
+  {
+    "username": "teamLead101",
+    "date": "2026-02-26",
+    "meals": null
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-26",
+    "meals": null
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-26",
+    "meals": null
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-27",
+    "meals": null
+  },
+  {
+    "username": "teamLead101",
+    "date": "2026-02-27",
+    "meals": null
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-27",
+    "meals": null
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-27",
+    "meals": null
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-28",
+    "meals": null
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-28",
+    "meals": null
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-28",
     "meals": null
   }
 ]

--- a/Root/Task-1/Project/Task 1 Iter 1/Backend/work_locations.json
+++ b/Root/Task-1/Project/Task 1 Iter 1/Backend/work_locations.json
@@ -7,12 +7,12 @@
   {
     "username": "employee101",
     "date": "2026-02-25",
-    "location": "Office"
+    "location": "WFH"
   },
   {
     "username": "employee101",
     "date": "2026-02-26",
-    "location": "Office"
+    "location": "WFH"
   },
   {
     "username": "teamLead101",
@@ -22,16 +22,111 @@
   {
     "username": "employee101",
     "date": "2026-02-28",
-    "location": "Office"
+    "location": "WFH"
   },
   {
     "username": "employee101",
     "date": "2026-02-27",
-    "location": "Office"
+    "location": "WFH"
   },
   {
     "username": "employee101",
     "date": "2026-02-24",
+    "location": "WFH"
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-24",
+    "location": "WFH"
+  },
+  {
+    "username": "teamLead101",
+    "date": "2026-02-24",
+    "location": "WFH"
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-24",
+    "location": "WFH"
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-24",
+    "location": "WFH"
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-25",
+    "location": "WFH"
+  },
+  {
+    "username": "teamLead101",
+    "date": "2026-02-25",
+    "location": "WFH"
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-25",
+    "location": "WFH"
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-25",
+    "location": "WFH"
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-26",
+    "location": "WFH"
+  },
+  {
+    "username": "teamLead101",
+    "date": "2026-02-26",
+    "location": "WFH"
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-26",
+    "location": "WFH"
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-26",
+    "location": "WFH"
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-27",
+    "location": "WFH"
+  },
+  {
+    "username": "teamLead101",
+    "date": "2026-02-27",
+    "location": "WFH"
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-27",
+    "location": "WFH"
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-27",
+    "location": "WFH"
+  },
+  {
+    "username": "admin1",
+    "date": "2026-02-28",
+    "location": "WFH"
+  },
+  {
+    "username": "employee102",
+    "date": "2026-02-28",
+    "location": "WFH"
+  },
+  {
+    "username": "employee201",
+    "date": "2026-02-28",
     "location": "WFH"
   }
 ]

--- a/Root/Task-1/Project/Task 1 Iter 1/frontend/src/pages/MealPlanner.tsx
+++ b/Root/Task-1/Project/Task 1 Iter 1/frontend/src/pages/MealPlanner.tsx
@@ -49,6 +49,48 @@ export default function MealPlanner() {
   const [specialNote, setSpecialNote] = useState("");
   const [currentDayStatus, setCurrentDayStatus] = useState<any>(null);
 
+  // ================= COMPANY-WIDE WFH =================
+const [companyWFHStart, setCompanyWFHStart] = useState("");
+const [companyWFHEnd, setCompanyWFHEnd] = useState("");
+const [companyWFHNote, setCompanyWFHNote] = useState("");
+const [companyWFHLoading, setCompanyWFHLoading] = useState(false);
+const [companyWFHMessage, setCompanyWFHMessage] = useState("");
+
+const applyCompanyWFH = async () => {
+  if (!companyWFHStart || !companyWFHEnd) {
+    alert("Select start and end date");
+    return;
+  }
+
+  setCompanyWFHLoading(true);
+  setCompanyWFHMessage("");
+
+  const res = await fetch("http://localhost:8080/admin/company-wfh", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      start_date: companyWFHStart,
+      end_date: companyWFHEnd,
+      note: companyWFHNote ? companyWFHNote : null,
+    }),
+  });
+
+  const data = await res.json();
+  setCompanyWFHLoading(false);
+
+  if (!res.ok) {
+    alert(data.error || "Failed to apply company WFH");
+    return;
+  }
+
+  setCompanyWFHMessage(
+    `Company-wide WFH applied for ${data.days_affected} days`
+  );
+};
+
   // ================= TEAM LEAD WORK LOCATION =================
   const [leadWorkDate, setLeadWorkDate] = useState("");
   const [leadWorkLocation, setLeadWorkLocation] = useState<"Office" | "WFH">("Office");
@@ -1510,6 +1552,50 @@ const updateAdminMemberWorkLocation = async () => {
     </div>
   )}
 </div>
+{/* ================= COMPANY-WIDE WFH PERIOD ================= */}
+{role === "admin" && (
+  <div className="section">
+    <h3>Company-wide WFH Period</h3>
+
+    <input
+      type="date"
+      className="input"
+      value={companyWFHStart}
+      onChange={e => setCompanyWFHStart(e.target.value)}
+    />
+
+    <input
+      type="date"
+      className="input"
+      value={companyWFHEnd}
+      onChange={e => setCompanyWFHEnd(e.target.value)}
+      style={{ marginTop: "10px" }}
+    />
+
+    <input
+      className="input"
+      placeholder="Optional note"
+      value={companyWFHNote}
+      onChange={e => setCompanyWFHNote(e.target.value)}
+      style={{ marginTop: "10px" }}
+    />
+
+    <button
+      className="btn primary"
+      style={{ marginTop: "12px" }}
+      onClick={applyCompanyWFH}
+      disabled={companyWFHLoading}
+    >
+      {companyWFHLoading ? "Applying..." : "Apply Company WFH"}
+    </button>
+
+    {companyWFHMessage && (
+      <p style={{ marginTop: "10px", color: "green" }}>
+        {companyWFHMessage}
+      </p>
+    )}
+  </div>
+)}
 
         <button className="btn danger logout" onClick={logout}>
           Logout


### PR DESCRIPTION
Closes #33

## Dependencies

- Merge PR #34

## What does this PR do?

- Allows Admin to declare a date range as a company-wide “WFH for everyone” period. During this period, employees are treated as WFH by default for reporting and headcount calculations.

## Type of Change

- [x] New feature

## What was changed

- **Admin**
  - Can define a start date and end date for a WFH period.
  - Can update or remove an existing WFH period.

- **System Behavior**
  - During the declared period:
    - Employees are treated as WFH by default.
    - Headcount reporting reflects all users as WFH unless explicitly overridden (if allowed).
    - Meals are opted out
  - Outside the declared period:
    - Normal work-location rules apply.


## Changelog


Feature: Company-wide WFH period



## How to Test

1. Manual Testing
2. Integration Testing

## How QA Should Test

- Create a WFH period
- Check employee meal and work status

## Rollback Plan

- Revert this PR


## Checklist

- [x] All requirements have been met
- [x] All tests pass

## Note for Reviewer

- Frontend has been implemented.