### PR TITLE
Implement Feature: Set Meal Participation status and Integrate with Discord Bot

### DIFF
--- a/Task 2/TDD.md
+++ b/Task 2/TDD.md
@@ -97,49 +97,107 @@ The dashboard communicates with backend APIs exposed via API Gateway.
 
 ## 1.4 DynamoDB Design (Single Table)
 
-**Table Name:** `MHP`
+**Table Name:** trainee-2026-samin-dynamoDB-mhp
 
-### Primary Key
-- `PK` (Partition Key)
-- `SK` (Sort Key)
+## Primary Keys
+- **PK** – Partition Key
+- **SK** – Sort Key
 
-The system stores multiple logical entities within a single DynamoDB table.
+## Conventions / Prefixes
+- `USER#<userId>` – user entity  
+- `TEAM#<teamId>` – team entity  
+- `DAY#<YYYY-MM-DD>` – date-based entity  
+- `MEAL#<mealType>` – meal type (lunch/dinner)  
+- `LOC#<locationType>` – work location (office/WFH)  
+- `SPECIAL#<YYYY-MM-DD>` – special day  
 
-#### Entities include:
 
-User  
-Team  
-Meal Participation  
-Work Location  
-Day Configuration  
-Meal Configuration
+---
 
-### Entity Patterns
+## Users
 
-| Entity                                              | PK                | SK                     | Purpose                                                                                                                                     |
-| --------------------------------------------------- | ----------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **User**                                            | `USER#<id>`       | `META`                 | Stores employee metadata: role, team. Essential for role-based access, team validation, and identifying users across meals and work locations.       |
-| **Meal Participation**                              | `MEAL#<date>`     | `USER#<id>#<mealType>` | Represents whether a user participates in a meal (Yes/No). Needed to track daily meal headcount, allow employees to opt-in/out, and generate reports.     |
-| **Work Location**                                   | `WORK#<date>`     | `USER#<id>`            | Stores where a user will work (Office/WFH) on a specific date. Necessary for linking attendance to meals and automating meal logic. |
-| **Day Configuration**                               | `DAY#<date>`      | `META`                 | Stores special days like holidays, office closed, and events. Needed to enforce date validation and cutoff rules.                                       |
-| **Team**                                            | `TEAM#<teamId>`   | `META`                 | Stores team metadata (name, lead, members). Will help in team based features like Team Lead meal management, and bulk operations and report generation.                           |
-| **Meal Configuration**  | `CONFIG#MEALTYPE` | `<mealType>`           | Stores allowed meal types (Lunch, Snacks, Event wise options) and settings. Supports admin operations to manage meals and enforce constraints.                     |
+### Access Patterns
+- Get user by `userId`  
+- Get user by external identity (e.g., `discordId`)  
+- Get all users  
 
-### Note: How they are queried will be explained feature by feature. For example, for feature 1 we will need to use GSI between user and team entity.
+### DB Schema
+- **PK:** USERS  
+- **SK:** `<userId>`  
 
-#### DynamoDB Access Patterns
+### Notes
+- User metadata stored in the item (role, team)  
+- Map user to team when adding a user to the Users entity  
 
-The DynamoDB schema is designed based on the following primary access patterns:
+---
 
-1. Get a user profile
-2. Get meal participation for a user on a specific date
-3. Get all meal participants for a specific date
-4. Get work location for a user on a specific date
-5. Get all users for a team
-6. Get day configuration for a specific date
-7. Update meal participation for a user
+## Team
 
-### Note: Access pattern can be modified based on new features based on which this will be updated. Also how these access patterns are executed is explained on feature level design. For feature one we will only need to deal with employees(only) meal participation.
+### Access Patterns
+- Get team by `teamId`  
+- Get all teams  
+- Get all users in a team  
+
+### DB Schema
+- **PK:** TEAM#<teamId>  
+- **SK:** USER#<userId>  
+
+### Notes
+- Scanning to get all teams is acceptable as it is rare and the dataset is small  
+
+---
+
+## Meal Participation
+
+### Access Patterns
+- Get all participation records for a date (daily totals)  
+- Get a specific user's meals for a date  
+- Get a specific meal record (user + date + mealType)  
+- Get a user's participation history across dates (reporting)  
+- Admin quick daily totals  
+- Team Lead quick team-level totals  
+
+### DB Schema
+- **PK:** DAY#<YYYY-MM-DD>  
+- **SK:** TEAM#<teamId>MEAL#<mealType>#USER#<userId>  
+
+### Notes
+- Admin daily totals: Query `PK = DAY#<date>` → all `MEAL#*` items  
+- Team Lead totals: Include `TEAM#<teamId>` as an attribute  
+
+---
+
+## Work Location
+
+### Access Patterns
+- Get all location records for a date (daily headcount)  
+- Get a specific user's location for a date  
+- Get a user's location records for a month  
+
+### DB Schema
+- **Date View:**  
+  - **PK:** DAY#<YYYY-MM-DD>  
+  - **SK:** USER#<userId>#LOC#<locationType>  
+
+- **User View:**  
+  - **PK:** USER#<userId>  
+  - **SK:** DAY#<YYYY-MM-DD>#LOC#<locationType>  
+
+### Notes
+- Records are stored twice since a single view cannot satisfy all access patterns  
+- Range search on PKs is not feasible  
+
+---
+
+## Special Day
+
+### Access Patterns
+- Get special day for a specific date  
+- Get all special days in a month  
+
+### DB Schema
+- **PK:** SPECIAL  
+- **SK:** Date#<YYYY-MM-DD>
 
 ---
 
@@ -186,7 +244,6 @@ Admin operations:
 
 Authorization checks occur in Lambda before database operations.
 
-#### Note: For iteration 1 lambda is not used. It will be built in interation 2.
 
 ## 1.6 Cross-Cutting Rules
 
@@ -222,30 +279,23 @@ Allows employees to manage meal participation. Limited to employee actions only.
   - Update restrictions (such as no update after cutoff time).
   - Role based access.
 
-## Entities
-
-| Entity                 | Attributes (for this feature)                                            | Purpose                                                     |
-| ---------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| **User**               | `role`, `teamId`                                                         | Validate role (EMPLOYEE) and team for internal Lambda logic |
-| **Meal Participation** | `participation` (YES/NO)                                                 | Core data for marking and tracking meals                    |
-| **Day Configuration**  | `type` (GOV HOLIDAY/CLOSED/EVENT)                                        | Used for read-only validation of date before update         |
-| **Team (via GSI)**     | `teamId`, `name`, `leadId`, `description`, `additionalMetadata`          | Supports team-level queries for Team Leads/Admins           |
-
-### Note: Team entity is not needed for feature 1 yet. Only shown for documentation as to show how User and Team entities will be connected. It is not needed as only admin/team lead can do team wise operations. 
-
-Stored in **single DynamoDB table (`MHP`)** with PK/SK prefixes: `USER#<id>`, `MEAL#<date>`, `DAY#<date>`
 
 ## Access Patterns & Queries
 
 1. **View own meals**
-   - `Query PK=MEAL#<date> SK begins_with USER#<userId>`
+Retrieve all meal records for a user on a specific date.
+   - `Query PK=DAY#<date> Filter: contains(SK, USER#<userId>)`
 
 2. **Update own meals**
-   - `PutItem PK=MEAL#<date> SK=USER#<userId>#<mealType>`
+The employee can opt in or opt out of a meal.
+   - `PutItem PK=DAY#<date> SK = TEAM#<teamId>#MEAL#<mealType>#USER#<userId>`
+   - Attributes: YES/NO
    - Lambda validates role, cutoff, closed day
 
 3. **Day validation**
-   - `Query PK=DAY#<date> SK=META`
+   - Before allowing updates, the system verifies whether the selected date is a special day.
+   - `Query PK=SPECIAL SK = DATE#<YYYY-MM-DD>`
+   - If result exists and type indicates closure, updates are rejected.
 
 ## User Flows
 
@@ -263,16 +313,16 @@ Stored in **single DynamoDB table (`MHP`)** with PK/SK prefixes: `USER#<id>`, `M
    - Update record
 4. Bot confirms action
 
-**PK:** `MEAL#<date>`  
-**SK:** begins_with `USER#<userId>#<mealType>`
+**PK:** `DAY#<date>`  
+**SK:** `TEAM#<teamId>#MEAL#<mealType>#USER#<userId>`
 
 ### View Status
 
 1. User runs `/meal view`
 2. Lambda queries:
 
-**PK:** `MEAL#<date>`  
-**SK:** begins_with `USER#<userId>`
+**PK:** `DAY#<date>`  
+**Filter:** `contains(SK, USER#<userId>)`
 
 
 3. Bot returns status

--- a/Task 2/backend/README.md
+++ b/Task 2/backend/README.md
@@ -66,3 +66,44 @@ Expected Response:
 {"date":"2026-03-10","meals":{"lunch":"YES","snacks":"YES"},"user_id":"your_discord_id"}
 
 ```
+
+### 2. Set Meal Status
+
+
+#### via discord bot ->
+
+- Use the `/meal view {date}` Discord slash command to check meal participation status for a specific date.
+
+**Command format:**
+```
+ /meal set date:YYYY-MM-DD meal_type:Lunch/Snacks status:Yes/No
+```
+**Example:**
+```
+/meal view date:2026-03-10 meal_type:Lunch status:No
+```
+
+**Expected Response:**
+```
+{"You have opted out of Lunch on 2026-03-13."}
+```
+
+#### via direct api call ->
+
+```cmd
+
+curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/meal/participation/set ^
+  -H "Content-Type: application/json" ^
+  -d "{\"discord_id\": \"123456789\", \"date\": \"2026-03-13\", \"meal_type\": \"lunch\", \"status\": \"NO\"}"
+
+```
+
+Expected Response:
+
+```
+{"message":"meal status updated successfully"}
+
+```
+
+
+

--- a/Task 2/backend/common/repository/meal_repository.go
+++ b/Task 2/backend/common/repository/meal_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
@@ -43,15 +44,14 @@ func GetUserMeals(userID string, date string) (map[string]string, error) {
 	db := database.GetDBClient()
 	table := database.GetTableName()
 
-	pk := "MEAL#" + date
-	prefix := "USER#" + userID
+	pk := "DAY#" + date
+	userFilter := "USER#" + userID
 
 	out, err := db.Query(&dynamodb.QueryInput{
 		TableName:              aws.String(table),
-		KeyConditionExpression: aws.String("PK = :pk AND begins_with(SK, :sk)"),
+		KeyConditionExpression: aws.String("PK = :pk"),
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			":pk": {S: aws.String(pk)},
-			":sk": {S: aws.String(prefix)},
 		},
 	})
 	if err != nil {
@@ -61,17 +61,21 @@ func GetUserMeals(userID string, date string) (map[string]string, error) {
 	result := map[string]string{}
 	for _, item := range out.Items {
 		sk := *item["SK"].S
-		if len(sk) >= 5 && sk[len(sk)-5:] == "lunch" {
-			result["lunch"] = *item["participation"].S
+		if !strings.Contains(sk, userFilter) {
+			continue
 		}
-		if len(sk) >= 6 && sk[len(sk)-6:] == "snacks" {
-			result["snacks"] = *item["participation"].S
+		// SK format: TEAM#<teamId>#MEAL#<mealType>#USER#<userId>
+		mealIdx := strings.Index(sk, "#MEAL#")
+		userIdx := strings.Index(sk, "#USER#")
+		if mealIdx >= 0 && userIdx > mealIdx {
+			mealType := sk[mealIdx+6 : userIdx]
+			result[mealType] = *item["participation"].S
 		}
 	}
 	return result, nil
 }
 
-func GetUserRole(discordID string) (string, error) {
+func GetUserRole(discordID string) (string, string, error) {
 	db := database.GetDBClient()
 	table := database.GetTableName()
 
@@ -83,26 +87,39 @@ func GetUserRole(discordID string) (string, error) {
 		},
 	})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if result.Item == nil {
-		return "", fmt.Errorf("user not found")
+		return "", "", fmt.Errorf("user not found")
 	}
+	role := ""
 	if v, ok := result.Item["role"]; ok && v.S != nil {
-		return *v.S, nil
+		role = *v.S
 	}
-	return "", fmt.Errorf("role not found for user")
+	teamID := ""
+	if v, ok := result.Item["teamId"]; ok && v.S != nil {
+		teamID = *v.S
+	}
+	if role == "" {
+		return "", "", fmt.Errorf("role not found for user")
+	}
+	if teamID == "" {
+		return "", "", fmt.Errorf("teamId not found for user")
+	}
+	return role, teamID, nil
 }
 
-func SetMealParticipation(userID, date, mealType, status string) error {
+func SetMealParticipation(userID, date, mealType, status, teamID string) error {
 	db := database.GetDBClient()
 	table := database.GetTableName()
+
+	sk := teamID + "#MEAL#" + mealType + "#USER#" + userID
 
 	_, err := db.PutItem(&dynamodb.PutItemInput{
 		TableName: aws.String(table),
 		Item: map[string]*dynamodb.AttributeValue{
-			"PK":            {S: aws.String("MEAL#" + date)},
-			"SK":            {S: aws.String("USER#" + userID + "#" + mealType)},
+			"PK":            {S: aws.String("DAY#" + date)},
+			"SK":            {S: aws.String(sk)},
 			"participation": {S: aws.String(status)},
 		},
 	})

--- a/Task 2/backend/common/repository/meal_repository.go
+++ b/Task 2/backend/common/repository/meal_repository.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
@@ -67,4 +69,42 @@ func GetUserMeals(userID string, date string) (map[string]string, error) {
 		}
 	}
 	return result, nil
+}
+
+func GetUserRole(discordID string) (string, error) {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	result, err := db.GetItem(&dynamodb.GetItemInput{
+		TableName: aws.String(table),
+		Key: map[string]*dynamodb.AttributeValue{
+			"PK": {S: aws.String("USER#" + discordID)},
+			"SK": {S: aws.String("META")},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if result.Item == nil {
+		return "", fmt.Errorf("user not found")
+	}
+	if v, ok := result.Item["role"]; ok && v.S != nil {
+		return *v.S, nil
+	}
+	return "", fmt.Errorf("role not found for user")
+}
+
+func SetMealParticipation(userID, date, mealType, status string) error {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	_, err := db.PutItem(&dynamodb.PutItemInput{
+		TableName: aws.String(table),
+		Item: map[string]*dynamodb.AttributeValue{
+			"PK":            {S: aws.String("MEAL#" + date)},
+			"SK":            {S: aws.String("USER#" + userID + "#" + mealType)},
+			"participation": {S: aws.String(status)},
+		},
+	})
+	return err
 }

--- a/Task 2/backend/common/service/meal_service.go
+++ b/Task 2/backend/common/service/meal_service.go
@@ -1,6 +1,10 @@
 package service
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/repository"
 )
 
@@ -33,4 +37,80 @@ func GetMealView(discordID string, date string) (*MealViewResponse, error) {
 		Meals:  result,
 		UserID: discordID,
 	}, nil
+}
+
+// ValidationError represents a user-facing validation failure (e.g. bad input, cutoff passed).
+type ValidationError struct {
+	Message string
+}
+
+func (e *ValidationError) Error() string { return e.Message }
+
+// SetMealStatus updates a user's participation for a specific meal type on a given date.
+// It enforces employee-only access and a 9pm cutoff for the following day's meals.
+func SetMealStatus(discordID, date, mealType, status string) error {
+	if err := repository.EnsureUserExists(discordID); err != nil {
+		return err
+	}
+
+	role, err := repository.GetUserRole(discordID)
+	if err != nil {
+		return err
+	}
+	if role != "EMPLOYEE" {
+		return &ValidationError{"only employees can update meal status"}
+	}
+
+	mealType = strings.ToLower(mealType)
+	if mealType != "lunch" && mealType != "snacks" {
+		return &ValidationError{fmt.Sprintf("invalid meal type '%s': must be 'lunch' or 'snacks'", mealType)}
+	}
+
+	status = strings.ToUpper(status)
+	if status != "YES" && status != "NO" {
+		return &ValidationError{fmt.Sprintf("invalid status '%s': must be 'YES' or 'NO'", status)}
+	}
+
+	locked, err := isPastCutoff(date)
+	if err != nil {
+		return &ValidationError{err.Error()}
+	}
+	if locked {
+		return &ValidationError{"the cutoff time (9pm) has passed — meal status can no longer be updated for this date"}
+	}
+
+	return repository.SetMealParticipation(discordID, date, mealType, status)
+}
+
+// isPastCutoff reports whether the cutoff for updating the given date has passed.
+// Rules (all times in IST / UTC+5:30):
+//   - Target date is today or in the past → always locked.
+//   - Target date is tomorrow → locked once it is past 9pm today.
+//   - Target date is two or more days away → not locked.
+func isPastCutoff(date string) (bool, error) {
+	targetDate, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return false, fmt.Errorf("invalid date format, expected YYYY-MM-DD")
+	}
+
+	ist := time.FixedZone("IST", 5*60*60+30*60)
+	now := time.Now().In(ist)
+
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, ist)
+	tomorrow := today.AddDate(0, 0, 1)
+	target := time.Date(targetDate.Year(), targetDate.Month(), targetDate.Day(), 0, 0, 0, 0, ist)
+
+	// Today or in the past
+	if !target.After(today) {
+		return true, nil
+	}
+
+	// Tomorrow: check 9pm cutoff
+	if target.Equal(tomorrow) {
+		cutoff := time.Date(now.Year(), now.Month(), now.Day(), 21, 0, 0, 0, ist)
+		return now.After(cutoff), nil
+	}
+
+	// Day after tomorrow or further: not locked
+	return false, nil
 }

--- a/Task 2/backend/common/service/meal_service.go
+++ b/Task 2/backend/common/service/meal_service.go
@@ -53,12 +53,9 @@ func SetMealStatus(discordID, date, mealType, status string) error {
 		return err
 	}
 
-	role, err := repository.GetUserRole(discordID)
+	_, teamID, err := repository.GetUserRole(discordID)
 	if err != nil {
 		return err
-	}
-	if role != "EMPLOYEE" {
-		return &ValidationError{"only employees can update meal status"}
 	}
 
 	mealType = strings.ToLower(mealType)
@@ -79,7 +76,7 @@ func SetMealStatus(discordID, date, mealType, status string) error {
 		return &ValidationError{"the cutoff time (9pm) has passed — meal status can no longer be updated for this date"}
 	}
 
-	return repository.SetMealParticipation(discordID, date, mealType, status)
+	return repository.SetMealParticipation(discordID, date, mealType, status, teamID)
 }
 
 // isPastCutoff reports whether the cutoff for updating the given date has passed.

--- a/Task 2/backend/lambdas/discord/commands/definitions.go
+++ b/Task 2/backend/lambdas/discord/commands/definitions.go
@@ -15,6 +15,12 @@ type SlashCommandOption struct {
 	Type        int                  `json:"type"`
 	Required    bool                 `json:"required,omitempty"`
 	Options     []SlashCommandOption `json:"options,omitempty"`
+	Choices     []SlashCommandChoice `json:"choices,omitempty"`
+}
+
+type SlashCommandChoice struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 // Definitions returns all slash commands that should be registered with Discord.
@@ -35,6 +41,39 @@ func Definitions() []SlashCommandDefinition {
 							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
 							Type:        3, // STRING
 							Required:    true,
+						},
+					},
+				},
+				{
+					Name:        "set",
+					Description: "Set your meal participation status for a specific date",
+					Type:        1, // SUB_COMMAND
+					Options: []SlashCommandOption{
+						{
+							Name:        "date",
+							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
+							Type:        3, // STRING
+							Required:    true,
+						},
+						{
+							Name:        "meal_type",
+							Description: "The meal to update",
+							Type:        3, // STRING
+							Required:    true,
+							Choices: []SlashCommandChoice{
+								{Name: "Lunch", Value: "lunch"},
+								{Name: "Snacks", Value: "snacks"},
+							},
+						},
+						{
+							Name:        "status",
+							Description: "YES to opt in, NO to opt out",
+							Type:        3, // STRING
+							Required:    true,
+							Choices: []SlashCommandChoice{
+								{Name: "YES — Opt in", Value: "YES"},
+								{Name: "NO — Opt out", Value: "NO"},
+							},
 						},
 					},
 				},

--- a/Task 2/backend/lambdas/discord/commands/meal.go
+++ b/Task 2/backend/lambdas/discord/commands/meal.go
@@ -32,6 +32,24 @@ func HandleMeal(data *types.CommandData, userID string) *types.InteractionRespon
 			return types.ErrorResponse("Please provide a date. Usage: `/meal view YYYY-MM-DD`")
 		}
 		return handleMealView(userID, date)
+	case "set":
+		var date, mealType, status string
+		for _, opt := range sub.Options {
+			if v, ok := opt.Value.(string); ok {
+				switch opt.Name {
+				case "date":
+					date = v
+				case "meal_type":
+					mealType = v
+				case "status":
+					status = v
+				}
+			}
+		}
+		if date == "" || mealType == "" || status == "" {
+			return types.ErrorResponse("Please provide all required options: date, meal_type, and status.")
+		}
+		return handleMealSet(userID, date, mealType, status)
 	default:
 		return types.ErrorResponse(fmt.Sprintf("Unknown subcommand: `%s`", sub.Name))
 	}
@@ -73,6 +91,39 @@ func handleMealView(userID string, date string) *types.InteractionResponse {
 		Color:  types.ColorSuccess,
 		Fields: fields,
 		Footer: &types.EmbedFooter{Text: "User: " + result.UserID},
+	})
+}
+
+type mealSetRequest struct {
+	DiscordID string `json:"discord_id"`
+	Date      string `json:"date"`
+	MealType  string `json:"meal_type"`
+	Status    string `json:"status"`
+}
+
+func handleMealSet(userID, date, mealType, status string) *types.InteractionResponse {
+	err := client.Post("/meal/participation/set", mealSetRequest{
+		DiscordID: userID,
+		Date:      date,
+		MealType:  mealType,
+		Status:    status,
+	}, nil)
+	if err != nil {
+		return types.ErrorResponse("Failed to update meal status: " + err.Error())
+	}
+
+	emoji := "✅"
+	optText := "opted **in** to"
+	if strings.EqualFold(status, "NO") {
+		emoji = "❌"
+		optText = "opted **out** of"
+	}
+
+	return types.EmbedResponse(types.Embed{
+		Title:       "Meal Status Updated",
+		Description: fmt.Sprintf("%s You have %s **%s** on %s.", emoji, optText, capitalize(mealType), date),
+		Color:       types.ColorSuccess,
+		Footer:      &types.EmbedFooter{Text: "User: " + userID},
 	})
 }
 

--- a/Task 2/backend/lambdas/set-meal-status/main.go
+++ b/Task 2/backend/lambdas/set-meal-status/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/config"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/service"
+)
+
+type SetMealStatusRequest struct {
+	DiscordID string `json:"discord_id"`
+	Date      string `json:"date"`
+	MealType  string `json:"meal_type"`
+	Status    string `json:"status"`
+}
+
+func SetMealStatusHandler(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var req SetMealStatusRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil ||
+		req.DiscordID == "" || req.Date == "" || req.MealType == "" || req.Status == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]string{"error": "invalid request: discord_id, date, meal_type, and status are required"}), nil
+	}
+
+	if err := service.SetMealStatus(req.DiscordID, req.Date, req.MealType, req.Status); err != nil {
+		var ve *service.ValidationError
+		if errors.As(err, &ve) {
+			return jsonResponse(http.StatusBadRequest, map[string]string{"error": err.Error()}), nil
+		}
+		return jsonResponse(http.StatusInternalServerError, map[string]string{"error": err.Error()}), nil
+	}
+
+	return jsonResponse(http.StatusOK, map[string]string{"message": "meal status updated successfully"}), nil
+}
+
+func jsonResponse(statusCode int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}
+
+func main() {
+	cfg := config.LoadConfig()
+	if err := database.InitDynamoDB(cfg); err != nil {
+		panic(err)
+	}
+	lambda.Start(SetMealStatusHandler)
+}


### PR DESCRIPTION
Closes #55 

## Dependencies

- Merge PR #54 

## What does this PR do?

- Implements updating meal participation status for a selected date and selected meal type and creates a discord bot slash command for it.

## Type of Change

- [x] Feature

## What was changed

- Updating meal status for a specified date and meal type feature has been added.
- Discord command for updating meal status has been added.

## How to Test

#### via discord bot ->

- Use the `/meal view {date}` Discord slash command to check meal participation status for a specific date.

**Command format:**
```
 /meal set date:YYYY-MM-DD meal_type:Lunch/Snacks status:Yes/No
```
**Example:**
```
/meal view date:2026-03-10 meal_type:Lunch status:No
```

**Expected Response:**
```
{"You have opted out of Lunch on 2026-03-13."}
```

#### via direct api call ->

```cmd

curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/meal/participation/set ^
  -H "Content-Type: application/json" ^
  -d "{\"discord_id\": \"123456789\", \"date\": \"2026-03-13\", \"meal_type\": \"lunch\", \"status\": \"NO\"}"

```

Expected Response:

```
{"message":"meal status updated successfully"}

```
#### DISCORD SERVER ->
```
https://discord.gg/94QjexfdQR
```

## Rollback Plan

- Revert this PR

## Checklist

- [x] Employees can update his meal status for a specified meal type and date.
- [x] A command for updating meal status has been added to the discord bot. 

## Note for Reviewer

- Some validations are not yet implemented such as verifying weather selected date is office closed or not. It is scheduled for modification when day control feature is implemented.