### PR TITLE
Implement Feature: Team Lead Meal Management

### DIFF
--- a/Task 2/backend/README.md
+++ b/Task 2/backend/README.md
@@ -105,5 +105,69 @@ Expected Response:
 
 ```
 
+### 3. Team Lead - Set Meal Status
 
+#### via discord bot ->
+
+- Use the `/team-meal set` Discord slash command to update a team member's meal participation status.
+
+**Command format:**
+```
+/team-meal set employee:@TeamMember date:YYYY-MM-DD meal_type:Lunch/Snacks status:Yes/No
+```
+**Example:**
+```
+/team-meal set employee:@JohnDoe date:2026-03-19 meal_type:Lunch status:No
+```
+
+**Expected Response:**
+```
+❌ @JohnDoe has been opted out of Lunch on 2026-03-19.
+```
+
+#### via direct api call ->
+
+```cmd
+curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/meal/team/set -H "Content-Type: application/json" -d "{\"team_lead_discord_id\": \"your_team_lead_discord_id\", \"target_discord_id\": \"employee_discord_id\", \"date\": \"2026-03-19\", \"meal_type\": \"lunch\", \"status\": \"NO\"}"
+```
+
+Expected Response:
+
+```
+{"message":"meal status updated successfully"}
+```
+
+### 4. Team Lead - View Meal Status
+
+#### via discord bot ->
+
+- Use the `/team-meal view` Discord slash command to view meal participation for all members of your team on a specific date.
+
+**Command format:**
+```
+/team-meal view date:YYYY-MM-DD
+```
+**Example:**
+```
+/team-meal view date:2026-03-19
+```
+
+**Expected Response:**
+```
+Team Meal Status — 2026-03-19
+@JohnDoe    ✅ Lunch: YES  |  ✅ Snacks: YES
+@JaneDoe    ❌ Lunch: NO   |  ✅ Snacks: YES
+```
+
+#### via direct api call ->
+
+```cmd
+curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/meal/team/view -H "Content-Type: application/json" -d "{\"team_lead_discord_id\": \"your_team_lead_discord_id\", \"date\": \"2026-03-19\"}"
+```
+
+Expected Response:
+
+```
+{"date":"2026-03-19","team_id":"TEAM#engineering","members":{"employee_discord_id":{"lunch":"YES","snacks":"YES"}}}
+```
 

--- a/Task 2/backend/common/repository/meal_repository.go
+++ b/Task 2/backend/common/repository/meal_repository.go
@@ -28,13 +28,27 @@ func EnsureUserExists(discordID string) error {
 		return nil
 	}
 
+	const defaultTeamID = "TEAM#engineering"
+
 	_, err = db.PutItem(&dynamodb.PutItemInput{
 		TableName: aws.String(table),
 		Item: map[string]*dynamodb.AttributeValue{
 			"PK":     {S: aws.String(pk)},
 			"SK":     {S: aws.String("META")},
 			"role":   {S: aws.String("EMPLOYEE")},
-			"teamId": {S: aws.String("TEAM#engineering")},
+			"teamId": {S: aws.String(defaultTeamID)},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	// Also create the team membership record so VerifyTeamMembership works.
+	_, err = db.PutItem(&dynamodb.PutItemInput{
+		TableName: aws.String(table),
+		Item: map[string]*dynamodb.AttributeValue{
+			"PK": {S: aws.String(defaultTeamID)},
+			"SK": {S: aws.String("USER#" + discordID)},
 		},
 	})
 	return err
@@ -124,4 +138,23 @@ func SetMealParticipation(userID, date, mealType, status, teamID string) error {
 		},
 	})
 	return err
+}
+
+// VerifyTeamMembership checks whether targetUserID is a member of the given team.
+// teamID must be in the stored format (e.g. "TEAM#engineering").
+func VerifyTeamMembership(teamID, targetUserID string) (bool, error) {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	result, err := db.GetItem(&dynamodb.GetItemInput{
+		TableName: aws.String(table),
+		Key: map[string]*dynamodb.AttributeValue{
+			"PK": {S: aws.String(teamID)},
+			"SK": {S: aws.String("USER#" + targetUserID)},
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return result.Item != nil, nil
 }

--- a/Task 2/backend/common/repository/meal_repository.go
+++ b/Task 2/backend/common/repository/meal_repository.go
@@ -140,6 +140,78 @@ func SetMealParticipation(userID, date, mealType, status, teamID string) error {
 	return err
 }
 
+// GetTeamMeals returns all meal participation records for a given team and date.
+// Result is a map of userID → map of mealType → participation status.
+func GetTeamMeals(teamID, date string) (map[string]map[string]string, error) {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	pk := "DAY#" + date
+	teamPrefix := teamID + "#MEAL#"
+
+	out, err := db.Query(&dynamodb.QueryInput{
+		TableName:              aws.String(table),
+		KeyConditionExpression: aws.String("PK = :pk AND begins_with(SK, :prefix)"),
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":pk":     {S: aws.String(pk)},
+			":prefix": {S: aws.String(teamPrefix)},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// SK format: TEAM#<teamId>#MEAL#<mealType>#USER#<userId>
+	result := map[string]map[string]string{}
+	for _, item := range out.Items {
+		sk := *item["SK"].S
+		mealIdx := strings.Index(sk, "#MEAL#")
+		userIdx := strings.Index(sk, "#USER#")
+		if mealIdx < 0 || userIdx <= mealIdx {
+			continue
+		}
+		mealType := sk[mealIdx+6 : userIdx]
+		userID := sk[userIdx+6:]
+		participation := ""
+		if v, ok := item["participation"]; ok && v.S != nil {
+			participation = *v.S
+		}
+		if result[userID] == nil {
+			result[userID] = map[string]string{}
+		}
+		result[userID][mealType] = participation
+	}
+	return result, nil
+}
+
+// GetTeamMembers returns all user IDs that belong to the given team.
+// teamID must be in the stored format (e.g. "TEAM#engineering").
+func GetTeamMembers(teamID string) ([]string, error) {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	out, err := db.Query(&dynamodb.QueryInput{
+		TableName:              aws.String(table),
+		KeyConditionExpression: aws.String("PK = :pk"),
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":pk": {S: aws.String(teamID)},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// SK format: USER#<userId>
+	var members []string
+	for _, item := range out.Items {
+		sk := *item["SK"].S
+		if strings.HasPrefix(sk, "USER#") {
+			members = append(members, sk[5:])
+		}
+	}
+	return members, nil
+}
+
 // VerifyTeamMembership checks whether targetUserID is a member of the given team.
 // teamID must be in the stored format (e.g. "TEAM#engineering").
 func VerifyTeamMembership(teamID, targetUserID string) (bool, error) {

--- a/Task 2/backend/common/service/meal_service.go
+++ b/Task 2/backend/common/service/meal_service.go
@@ -79,6 +79,46 @@ func SetMealStatus(discordID, date, mealType, status string) error {
 	return repository.SetMealParticipation(discordID, date, mealType, status, teamID)
 }
 
+// TeamLeadSetMealStatus updates a team member's meal participation on behalf of a team lead.
+// It enforces team-lead-only access, team boundary restrictions, and a 9pm cutoff.
+func TeamLeadSetMealStatus(teamLeadID, targetUserID, date, mealType, status string) error {
+	role, teamID, err := repository.GetUserRole(teamLeadID)
+	if err != nil {
+		return err
+	}
+	if role != "TEAM_LEAD" {
+		return &ValidationError{"access denied: only team leads can perform this action"}
+	}
+
+	isMember, err := repository.VerifyTeamMembership(teamID, targetUserID)
+	if err != nil {
+		return err
+	}
+	if !isMember {
+		return &ValidationError{"access denied: target user does not belong to your team"}
+	}
+
+	mealType = strings.ToLower(mealType)
+	if mealType != "lunch" && mealType != "snacks" {
+		return &ValidationError{fmt.Sprintf("invalid meal type '%s': must be 'lunch' or 'snacks'", mealType)}
+	}
+
+	status = strings.ToUpper(status)
+	if status != "YES" && status != "NO" {
+		return &ValidationError{fmt.Sprintf("invalid status '%s': must be 'YES' or 'NO'", status)}
+	}
+
+	locked, err := isPastCutoff(date)
+	if err != nil {
+		return &ValidationError{err.Error()}
+	}
+	if locked {
+		return &ValidationError{"the cutoff time (9pm) has passed — meal status can no longer be updated for this date"}
+	}
+
+	return repository.SetMealParticipation(targetUserID, date, mealType, status, teamID)
+}
+
 // isPastCutoff reports whether the cutoff for updating the given date has passed.
 // Rules (all times in IST / UTC+5:30):
 //   - Target date is today or in the past → always locked.

--- a/Task 2/backend/common/service/meal_service.go
+++ b/Task 2/backend/common/service/meal_service.go
@@ -79,6 +79,58 @@ func SetMealStatus(discordID, date, mealType, status string) error {
 	return repository.SetMealParticipation(discordID, date, mealType, status, teamID)
 }
 
+type TeamMealViewResponse struct {
+	Date    string                       `json:"date"`
+	TeamID  string                       `json:"team_id"`
+	Members map[string]map[string]string `json:"members"`
+}
+
+// mealTypes lists all supported meal types used to fill in defaults.
+var mealTypes = []string{"lunch", "snacks"}
+
+// TeamLeadGetMealView returns meal participation for all members of the team lead's team on a given date.
+// Any meal type not explicitly recorded defaults to YES.
+func TeamLeadGetMealView(teamLeadID, date string) (*TeamMealViewResponse, error) {
+	role, teamID, err := repository.GetUserRole(teamLeadID)
+	if err != nil {
+		return nil, err
+	}
+	if role != "TEAM_LEAD" {
+		return nil, &ValidationError{"access denied: only team leads can perform this action"}
+	}
+
+	teamMembers, err := repository.GetTeamMembers(teamID)
+	if err != nil {
+		return nil, err
+	}
+
+	existing, err := repository.GetTeamMeals(teamID, date)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build result: every member gets every meal type, defaulting to YES.
+	result := make(map[string]map[string]string, len(teamMembers))
+	for _, memberID := range teamMembers {
+		meals := map[string]string{}
+		for _, mt := range mealTypes {
+			meals[mt] = "YES"
+		}
+		if recorded, ok := existing[memberID]; ok {
+			for mt, status := range recorded {
+				meals[mt] = status
+			}
+		}
+		result[memberID] = meals
+	}
+
+	return &TeamMealViewResponse{
+		Date:    date,
+		TeamID:  teamID,
+		Members: result,
+	}, nil
+}
+
 // TeamLeadSetMealStatus updates a team member's meal participation on behalf of a team lead.
 // It enforces team-lead-only access, team boundary restrictions, and a 9pm cutoff.
 func TeamLeadSetMealStatus(teamLeadID, targetUserID, date, mealType, status string) error {

--- a/Task 2/backend/lambdas/discord/commands/definitions.go
+++ b/Task 2/backend/lambdas/discord/commands/definitions.go
@@ -79,5 +79,50 @@ func Definitions() []SlashCommandDefinition {
 				},
 			},
 		},
+		{
+			Name:        "team-meal",
+			Description: "Manage meal participation for your team members (Team Lead only)",
+			Options: []SlashCommandOption{
+				{
+					Name:        "set",
+					Description: "Set a team member's meal participation status",
+					Type:        1, // SUB_COMMAND
+					Options: []SlashCommandOption{
+						{
+							Name:        "employee",
+							Description: "The team member to update",
+							Type:        6, // USER
+							Required:    true,
+						},
+						{
+							Name:        "date",
+							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
+							Type:        3, // STRING
+							Required:    true,
+						},
+						{
+							Name:        "meal_type",
+							Description: "The meal to update",
+							Type:        3, // STRING
+							Required:    true,
+							Choices: []SlashCommandChoice{
+								{Name: "Lunch", Value: "lunch"},
+								{Name: "Snacks", Value: "snacks"},
+							},
+						},
+						{
+							Name:        "status",
+							Description: "YES to opt in, NO to opt out",
+							Type:        3, // STRING
+							Required:    true,
+							Choices: []SlashCommandChoice{
+								{Name: "YES — Opt in", Value: "YES"},
+								{Name: "NO — Opt out", Value: "NO"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/Task 2/backend/lambdas/discord/commands/definitions.go
+++ b/Task 2/backend/lambdas/discord/commands/definitions.go
@@ -84,6 +84,19 @@ func Definitions() []SlashCommandDefinition {
 			Description: "Manage meal participation for your team members (Team Lead only)",
 			Options: []SlashCommandOption{
 				{
+					Name:        "view",
+					Description: "View meal participation for your team on a specific date",
+					Type:        1, // SUB_COMMAND
+					Options: []SlashCommandOption{
+						{
+							Name:        "date",
+							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
+							Type:        3, // STRING
+							Required:    true,
+						},
+					},
+				},
+				{
 					Name:        "set",
 					Description: "Set a team member's meal participation status",
 					Type:        1, // SUB_COMMAND

--- a/Task 2/backend/lambdas/discord/commands/team_meal.go
+++ b/Task 2/backend/lambdas/discord/commands/team_meal.go
@@ -2,6 +2,8 @@ package commands
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/client"
 	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/types"
@@ -14,11 +16,22 @@ func init() {
 // HandleTeamMeal routes /team-meal subcommands.
 func HandleTeamMeal(data *types.CommandData, userID string) *types.InteractionResponse {
 	if len(data.Options) == 0 {
-		return types.ErrorResponse("Please provide a subcommand. Usage: `/team-meal set`")
+		return types.ErrorResponse("Please provide a subcommand. Usage: `/team-meal view` or `/team-meal set`")
 	}
 
 	sub := data.Options[0]
 	switch sub.Name {
+	case "view":
+		date := ""
+		if len(sub.Options) > 0 {
+			if v, ok := sub.Options[0].Value.(string); ok {
+				date = v
+			}
+		}
+		if date == "" {
+			return types.ErrorResponse("Please provide a date.")
+		}
+		return handleTeamMealView(userID, date)
 	case "set":
 		var targetUserID, date, mealType, status string
 		for _, opt := range sub.Options {
@@ -49,6 +62,73 @@ func HandleTeamMeal(data *types.CommandData, userID string) *types.InteractionRe
 	default:
 		return types.ErrorResponse(fmt.Sprintf("Unknown subcommand: `%s`", sub.Name))
 	}
+}
+
+type teamMealViewRequest struct {
+	TeamLeadDiscordID string `json:"team_lead_discord_id"`
+	Date              string `json:"date"`
+}
+
+type teamMealViewResponse struct {
+	Date    string                       `json:"date"`
+	TeamID  string                       `json:"team_id"`
+	Members map[string]map[string]string `json:"members"`
+}
+
+func handleTeamMealView(teamLeadID, date string) *types.InteractionResponse {
+	var result teamMealViewResponse
+	err := client.Post("/meal/team/view", teamMealViewRequest{
+		TeamLeadDiscordID: teamLeadID,
+		Date:              date,
+	}, &result)
+	if err != nil {
+		return types.ErrorResponse("Failed to fetch team meal status: " + err.Error())
+	}
+
+	if len(result.Members) == 0 {
+		return types.EmbedResponse(types.Embed{
+			Title:       "Team Meal Status — " + date,
+			Description: "No team members found.",
+			Color:       types.ColorInfo,
+		})
+	}
+
+	// One field per member showing all meal statuses on one line.
+	fields := make([]types.EmbedField, 0, len(result.Members))
+
+	// Sort member IDs for consistent ordering.
+	memberIDs := make([]string, 0, len(result.Members))
+	for id := range result.Members {
+		memberIDs = append(memberIDs, id)
+	}
+	sort.Strings(memberIDs)
+
+	for _, memberID := range memberIDs {
+		meals := result.Members[memberID]
+		parts := make([]string, 0, len(meals))
+		for _, mt := range []string{"lunch", "snacks"} {
+			status, ok := meals[mt]
+			if !ok {
+				continue
+			}
+			emoji := "✅"
+			if strings.EqualFold(status, "NO") {
+				emoji = "❌"
+			}
+			parts = append(parts, fmt.Sprintf("%s %s: %s", emoji, capitalize(mt), status))
+		}
+		fields = append(fields, types.EmbedField{
+			Name:  fmt.Sprintf("<@%s>", memberID),
+			Value: strings.Join(parts, "  |  "),
+		})
+	}
+
+	return types.EmbedResponse(types.Embed{
+		Title:  "Team Meal Status — " + date,
+		Color:  types.ColorInfo,
+		Fields: fields,
+		Footer: &types.EmbedFooter{Text: result.TeamID},
+	})
 }
 
 type teamMealSetRequest struct {

--- a/Task 2/backend/lambdas/discord/commands/team_meal.go
+++ b/Task 2/backend/lambdas/discord/commands/team_meal.go
@@ -1,0 +1,87 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/client"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/types"
+)
+
+func init() {
+	Register("team-meal", HandleTeamMeal)
+}
+
+// HandleTeamMeal routes /team-meal subcommands.
+func HandleTeamMeal(data *types.CommandData, userID string) *types.InteractionResponse {
+	if len(data.Options) == 0 {
+		return types.ErrorResponse("Please provide a subcommand. Usage: `/team-meal set`")
+	}
+
+	sub := data.Options[0]
+	switch sub.Name {
+	case "set":
+		var targetUserID, date, mealType, status string
+		for _, opt := range sub.Options {
+			switch opt.Name {
+			case "employee":
+				// Discord USER option returns the user's snowflake ID as a string value.
+				if v, ok := opt.Value.(string); ok {
+					targetUserID = v
+				}
+			case "date":
+				if v, ok := opt.Value.(string); ok {
+					date = v
+				}
+			case "meal_type":
+				if v, ok := opt.Value.(string); ok {
+					mealType = v
+				}
+			case "status":
+				if v, ok := opt.Value.(string); ok {
+					status = v
+				}
+			}
+		}
+		if targetUserID == "" || date == "" || mealType == "" || status == "" {
+			return types.ErrorResponse("Please provide all required options: employee, date, meal_type, and status.")
+		}
+		return handleTeamMealSet(userID, targetUserID, date, mealType, status)
+	default:
+		return types.ErrorResponse(fmt.Sprintf("Unknown subcommand: `%s`", sub.Name))
+	}
+}
+
+type teamMealSetRequest struct {
+	TeamLeadDiscordID string `json:"team_lead_discord_id"`
+	TargetDiscordID   string `json:"target_discord_id"`
+	Date              string `json:"date"`
+	MealType          string `json:"meal_type"`
+	Status            string `json:"status"`
+}
+
+func handleTeamMealSet(teamLeadID, targetUserID, date, mealType, status string) *types.InteractionResponse {
+	err := client.Post("/meal/team/set", teamMealSetRequest{
+		TeamLeadDiscordID: teamLeadID,
+		TargetDiscordID:   targetUserID,
+		Date:              date,
+		MealType:          mealType,
+		Status:            status,
+	}, nil)
+	if err != nil {
+		return types.ErrorResponse("Failed to update meal status: " + err.Error())
+	}
+
+	emoji := "✅"
+	optText := "opted **in** to"
+	if status == "NO" {
+		emoji = "❌"
+		optText = "opted **out** of"
+	}
+
+	return types.EmbedResponse(types.Embed{
+		Title:       "Team Meal Status Updated",
+		Description: fmt.Sprintf("%s <@%s> has been %s **%s** on %s.", emoji, targetUserID, optText, capitalize(mealType), date),
+		Color:       types.ColorSuccess,
+		Footer:      &types.EmbedFooter{Text: "Updated by: " + teamLeadID},
+	})
+}

--- a/Task 2/backend/lambdas/set-team-meal-status/main.go
+++ b/Task 2/backend/lambdas/set-team-meal-status/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/config"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/service"
+)
+
+type SetTeamMealStatusRequest struct {
+	TeamLeadDiscordID string `json:"team_lead_discord_id"`
+	TargetDiscordID   string `json:"target_discord_id"`
+	Date              string `json:"date"`
+	MealType          string `json:"meal_type"`
+	Status            string `json:"status"`
+}
+
+func SetTeamMealStatusHandler(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var req SetTeamMealStatusRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil ||
+		req.TeamLeadDiscordID == "" || req.TargetDiscordID == "" ||
+		req.Date == "" || req.MealType == "" || req.Status == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]string{
+			"error": "invalid request: team_lead_discord_id, target_discord_id, date, meal_type, and status are required",
+		}), nil
+	}
+
+	if err := service.TeamLeadSetMealStatus(req.TeamLeadDiscordID, req.TargetDiscordID, req.Date, req.MealType, req.Status); err != nil {
+		var ve *service.ValidationError
+		if errors.As(err, &ve) {
+			return jsonResponse(http.StatusBadRequest, map[string]string{"error": err.Error()}), nil
+		}
+		return jsonResponse(http.StatusInternalServerError, map[string]string{"error": err.Error()}), nil
+	}
+
+	return jsonResponse(http.StatusOK, map[string]string{"message": "meal status updated successfully"}), nil
+}
+
+func jsonResponse(statusCode int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}
+
+func main() {
+	cfg := config.LoadConfig()
+	if err := database.InitDynamoDB(cfg); err != nil {
+		panic(err)
+	}
+	lambda.Start(SetTeamMealStatusHandler)
+}

--- a/Task 2/backend/lambdas/view-team-meal-participation/main.go
+++ b/Task 2/backend/lambdas/view-team-meal-participation/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/config"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/service"
+)
+
+type ViewTeamMealRequest struct {
+	TeamLeadDiscordID string `json:"team_lead_discord_id"`
+	Date              string `json:"date"`
+}
+
+func ViewTeamMealParticipationHandler(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var req ViewTeamMealRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil ||
+		req.TeamLeadDiscordID == "" || req.Date == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]string{
+			"error": "invalid request: team_lead_discord_id and date are required",
+		}), nil
+	}
+
+	result, err := service.TeamLeadGetMealView(req.TeamLeadDiscordID, req.Date)
+	if err != nil {
+		var ve *service.ValidationError
+		if errors.As(err, &ve) {
+			return jsonResponse(http.StatusBadRequest, map[string]string{"error": err.Error()}), nil
+		}
+		return jsonResponse(http.StatusInternalServerError, map[string]string{"error": err.Error()}), nil
+	}
+
+	return jsonResponse(http.StatusOK, result), nil
+}
+
+func jsonResponse(statusCode int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}
+
+func main() {
+	cfg := config.LoadConfig()
+	if err := database.InitDynamoDB(cfg); err != nil {
+		panic(err)
+	}
+	lambda.Start(ViewTeamMealParticipationHandler)
+}


### PR DESCRIPTION
Closes #45

## Dependencies

- Merge PR #59

## What does this PR do?

- Implements feature where team lead can view and update the statuses of his own team members for a specific date.

## Type of Change

- [x] Feature

## What was changed

- Team lead can change the meal status of his team members for a specific date
- Team lead can view the meal status of his team members for a specific date
- Two new discord commands have been added


## How to Test

### 1. Team Lead - Set Meal Status

#### via discord bot ->

- Use the `/team-meal set` Discord slash command to update a team member's meal participation status.

**Command format:**
```
/team-meal set employee:@TeamMember date:YYYY-MM-DD meal_type:Lunch/Snacks status:Yes/No
```
**Example:**
```
/team-meal set employee:@JohnDoe date:2026-03-19 meal_type:Lunch status:No
```

**Expected Response:**
```
❌ @ID has been opted out of Lunch on 2026-03-19.
```

#### via direct api call ->

```cmd
curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/meal/team/set -H "Content-Type: application/json" -d "{\"team_lead_discord_id\": \"your_team_lead_discord_id\", \"target_discord_id\": \"employee_discord_id\", \"date\": \"2026-03-19\", \"meal_type\": \"lunch\", \"status\": \"NO\"}"
```

Expected Response:

```
{"message":"meal status updated successfully"}
```

### 2. Team Lead - View Meal Status

#### via discord bot ->

- Use the `/team-meal view` Discord slash command to view meal participation for all members of your team on a specific date.

**Command format:**
```
/team-meal view date:YYYY-MM-DD
```
**Example:**
```
/team-meal view date:2026-03-19
```

**Expected Response:**
```
Team Meal Status — 2026-03-19
@ID    ✅ Lunch: YES  |  ✅ Snacks: YES
@ID    ❌ Lunch: NO   |  ✅ Snacks: YES
```

#### via direct api call ->

```cmd
curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/meal/team/view -H "Content-Type: application/json" -d "{\"team_lead_discord_id\": \"your_team_lead_discord_id\", \"date\": \"2026-03-19\"}"
```

Expected Response:

```
{"date":"2026-03-19","team_id":"TEAM#engineering","members":{"employee_discord_id":{"lunch":"YES","snacks":"YES"}}}
```
#### DISCORD SERVER ->
```
https://discord.gg/94QjexfdQR
```

## Checklist

- [x] Team Lead can update the meal status of his team member for a specific date.
- [x] Team Lead can view the meal status of his team members for a specific date.
- [x] Discord commands for the added features are functional.  
