### PR TITLE
Implement Feature: Admin Meal Management

### DIFF
--- a/Task 2/backend/common/service/meal_service.go
+++ b/Task 2/backend/common/service/meal_service.go
@@ -171,6 +171,80 @@ func TeamLeadSetMealStatus(teamLeadID, targetUserID, date, mealType, status stri
 	return repository.SetMealParticipation(targetUserID, date, mealType, status, teamID)
 }
 
+type AdminMealViewResponse struct {
+	Date   string            `json:"date"`
+	UserID string            `json:"user_id"`
+	Meals  map[string]string `json:"meals"`
+}
+
+// AdminGetMealView returns meal participation for a specific employee on a given date.
+// Only admins can use this. Missing records default to YES (opted-in by default).
+func AdminGetMealView(adminID, targetUserID, date string) (*AdminMealViewResponse, error) {
+	role, _, err := repository.GetUserRole(adminID)
+	if err != nil {
+		return nil, err
+	}
+	if role != "ADMIN" {
+		return nil, &ValidationError{"access denied: only admins can perform this action"}
+	}
+
+	meals, err := repository.GetUserMeals(targetUserID, date)
+	if err != nil {
+		return nil, err
+	}
+
+	result := map[string]string{}
+	for _, mt := range mealTypes {
+		result[mt] = "YES"
+	}
+	for mealType, participation := range meals {
+		result[mealType] = participation
+	}
+
+	return &AdminMealViewResponse{
+		Date:   date,
+		UserID: targetUserID,
+		Meals:  result,
+	}, nil
+}
+
+// AdminSetMealStatus updates any employee's meal participation on behalf of an admin.
+// It enforces admin-only access and a 9pm cutoff for the following day's meals.
+func AdminSetMealStatus(adminID, targetUserID, date, mealType, status string) error {
+	role, _, err := repository.GetUserRole(adminID)
+	if err != nil {
+		return err
+	}
+	if role != "ADMIN" {
+		return &ValidationError{"access denied: only admins can perform this action"}
+	}
+
+	mealType = strings.ToLower(mealType)
+	if mealType != "lunch" && mealType != "snacks" {
+		return &ValidationError{fmt.Sprintf("invalid meal type '%s': must be 'lunch' or 'snacks'", mealType)}
+	}
+
+	status = strings.ToUpper(status)
+	if status != "YES" && status != "NO" {
+		return &ValidationError{fmt.Sprintf("invalid status '%s': must be 'YES' or 'NO'", status)}
+	}
+
+	locked, err := isPastCutoff(date)
+	if err != nil {
+		return &ValidationError{err.Error()}
+	}
+	if locked {
+		return &ValidationError{"the cutoff time (9pm) has passed — meal status can no longer be updated for this date"}
+	}
+
+	_, targetTeamID, err := repository.GetUserRole(targetUserID)
+	if err != nil {
+		return err
+	}
+
+	return repository.SetMealParticipation(targetUserID, date, mealType, status, targetTeamID)
+}
+
 // isPastCutoff reports whether the cutoff for updating the given date has passed.
 // Rules (all times in IST / UTC+5:30):
 //   - Target date is today or in the past → always locked.

--- a/Task 2/backend/common/service/meal_service.go
+++ b/Task 2/backend/common/service/meal_service.go
@@ -46,6 +46,18 @@ type ValidationError struct {
 
 func (e *ValidationError) Error() string { return e.Message }
 
+// validateAdminAccess checks if the given user has admin role.
+func validateAdminAccess(adminID string) error {
+	role, _, err := repository.GetUserRole(adminID)
+	if err != nil {
+		return err
+	}
+	if role != "ADMIN" {
+		return &ValidationError{"access denied: only admins can perform this action"}
+	}
+	return nil
+}
+
 // SetMealStatus updates a user's participation for a specific meal type on a given date.
 // It enforces employee-only access and a 9pm cutoff for the following day's meals.
 func SetMealStatus(discordID, date, mealType, status string) error {
@@ -180,12 +192,8 @@ type AdminMealViewResponse struct {
 // AdminGetMealView returns meal participation for a specific employee on a given date.
 // Only admins can use this. Missing records default to YES (opted-in by default).
 func AdminGetMealView(adminID, targetUserID, date string) (*AdminMealViewResponse, error) {
-	role, _, err := repository.GetUserRole(adminID)
-	if err != nil {
+	if err := validateAdminAccess(adminID); err != nil {
 		return nil, err
-	}
-	if role != "ADMIN" {
-		return nil, &ValidationError{"access denied: only admins can perform this action"}
 	}
 
 	meals, err := repository.GetUserMeals(targetUserID, date)
@@ -211,12 +219,8 @@ func AdminGetMealView(adminID, targetUserID, date string) (*AdminMealViewRespons
 // AdminSetMealStatus updates any employee's meal participation on behalf of an admin.
 // It enforces admin-only access and a 9pm cutoff for the following day's meals.
 func AdminSetMealStatus(adminID, targetUserID, date, mealType, status string) error {
-	role, _, err := repository.GetUserRole(adminID)
-	if err != nil {
+	if err := validateAdminAccess(adminID); err != nil {
 		return err
-	}
-	if role != "ADMIN" {
-		return &ValidationError{"access denied: only admins can perform this action"}
 	}
 
 	mealType = strings.ToLower(mealType)

--- a/Task 2/backend/lambdas/discord/commands/admin_meal.go
+++ b/Task 2/backend/lambdas/discord/commands/admin_meal.go
@@ -1,0 +1,145 @@
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/client"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/types"
+)
+
+func init() {
+	Register("admin-meal", HandleAdminMeal)
+}
+
+// HandleAdminMeal routes /admin-meal subcommands.
+func HandleAdminMeal(data *types.CommandData, userID string) *types.InteractionResponse {
+	if len(data.Options) == 0 {
+		return types.ErrorResponse("Please provide a subcommand. Usage: `/admin-meal view` or `/admin-meal set`")
+	}
+
+	sub := data.Options[0]
+	switch sub.Name {
+	case "view":
+		var targetUserID, date string
+		for _, opt := range sub.Options {
+			if v, ok := opt.Value.(string); ok {
+				switch opt.Name {
+				case "employee":
+					targetUserID = v
+				case "date":
+					date = v
+				}
+			}
+		}
+		if targetUserID == "" || date == "" {
+			return types.ErrorResponse("Please provide all required options: employee and date.")
+		}
+		return handleAdminMealView(userID, targetUserID, date)
+	case "set":
+		var targetUserID, date, mealType, status string
+		for _, opt := range sub.Options {
+			if v, ok := opt.Value.(string); ok {
+				switch opt.Name {
+				case "employee":
+					targetUserID = v
+				case "date":
+					date = v
+				case "meal_type":
+					mealType = v
+				case "status":
+					status = v
+				}
+			}
+		}
+		if targetUserID == "" || date == "" || mealType == "" || status == "" {
+			return types.ErrorResponse("Please provide all required options: employee, date, meal_type, and status.")
+		}
+		return handleAdminMealSet(userID, targetUserID, date, mealType, status)
+	default:
+		return types.ErrorResponse(fmt.Sprintf("Unknown subcommand: `%s`", sub.Name))
+	}
+}
+
+type adminMealViewRequest struct {
+	AdminDiscordID  string `json:"admin_discord_id"`
+	TargetDiscordID string `json:"target_discord_id"`
+	Date            string `json:"date"`
+}
+
+type adminMealViewResponse struct {
+	Date   string            `json:"date"`
+	UserID string            `json:"user_id"`
+	Meals  map[string]string `json:"meals"`
+}
+
+func handleAdminMealView(adminID, targetUserID, date string) *types.InteractionResponse {
+	var result adminMealViewResponse
+	err := client.Post("/meal/admin/view", adminMealViewRequest{
+		AdminDiscordID:  adminID,
+		TargetDiscordID: targetUserID,
+		Date:            date,
+	}, &result)
+	if err != nil {
+		return types.ErrorResponse("Failed to fetch meal participation: " + err.Error())
+	}
+
+	fields := make([]types.EmbedField, 0, len(result.Meals))
+	for _, mt := range []string{"lunch", "snacks"} {
+		participation, ok := result.Meals[mt]
+		if !ok {
+			continue
+		}
+		emoji := "✅"
+		if strings.EqualFold(participation, "NO") {
+			emoji = "❌"
+		}
+		fields = append(fields, types.EmbedField{
+			Name:   capitalize(mt),
+			Value:  fmt.Sprintf("%s %s", emoji, participation),
+			Inline: true,
+		})
+	}
+
+	return types.EmbedResponse(types.Embed{
+		Title:  "Meal Participation — " + result.Date,
+		Color:  types.ColorInfo,
+		Fields: fields,
+		Footer: &types.EmbedFooter{Text: "Employee: " + result.UserID},
+	})
+}
+
+type adminMealSetRequest struct {
+	AdminDiscordID  string `json:"admin_discord_id"`
+	TargetDiscordID string `json:"target_discord_id"`
+	Date            string `json:"date"`
+	MealType        string `json:"meal_type"`
+	Status          string `json:"status"`
+}
+
+func handleAdminMealSet(adminID, targetUserID, date, mealType, status string) *types.InteractionResponse {
+	err := client.Post("/meal/admin/set", adminMealSetRequest{
+		AdminDiscordID:  adminID,
+		TargetDiscordID: targetUserID,
+		Date:            date,
+		MealType:        mealType,
+		Status:          status,
+	}, nil)
+	if err != nil {
+		return types.ErrorResponse("Failed to update meal status: " + err.Error())
+	}
+
+	emoji := "✅"
+	optText := "opted **in** to"
+	if strings.EqualFold(status, "NO") {
+		emoji = "❌"
+		optText = "opted **out** of"
+	}
+
+	return types.EmbedResponse(types.Embed{
+		Title:       "Admin Meal Status Updated",
+		Description: fmt.Sprintf("%s <@%s> has been %s **%s** on %s.", emoji, targetUserID, optText, capitalize(mealType), date),
+		Color:       types.ColorSuccess,
+		Footer:      &types.EmbedFooter{Text: "Updated by admin: " + adminID},
+	})
+}

--- a/Task 2/backend/lambdas/discord/commands/admin_meal.go
+++ b/Task 2/backend/lambdas/discord/commands/admin_meal.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -10,6 +11,31 @@ import (
 
 func init() {
 	Register("admin-meal", HandleAdminMeal)
+}
+
+// extractAPIErrorMessage parses API error responses to get the actual error message.
+// API errors come in format: "API /path returned status 400: {"error": "actual message"}"
+func extractAPIErrorMessage(err error) string {
+	errStr := err.Error()
+	
+	// Find the JSON part after the colon
+	colonIndex := strings.LastIndex(errStr, ": ")
+	if colonIndex == -1 {
+		return errStr
+	}
+	
+	jsonStr := errStr[colonIndex+2:]
+	
+	// Try to parse as JSON
+	var errorResp struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal([]byte(jsonStr), &errorResp) == nil && errorResp.Error != "" {
+		return errorResp.Error
+	}
+	
+	// Fallback to original error if parsing fails
+	return errStr
 }
 
 // HandleAdminMeal routes /admin-meal subcommands.
@@ -81,7 +107,7 @@ func handleAdminMealView(adminID, targetUserID, date string) *types.InteractionR
 		Date:            date,
 	}, &result)
 	if err != nil {
-		return types.ErrorResponse("Failed to fetch meal participation: " + err.Error())
+		return types.ErrorResponse("Failed to fetch meal participation: " + extractAPIErrorMessage(err))
 	}
 
 	fields := make([]types.EmbedField, 0, len(result.Meals))
@@ -126,7 +152,7 @@ func handleAdminMealSet(adminID, targetUserID, date, mealType, status string) *t
 		Status:          status,
 	}, nil)
 	if err != nil {
-		return types.ErrorResponse("Failed to update meal status: " + err.Error())
+		return types.ErrorResponse("Failed to update meal status: " + extractAPIErrorMessage(err))
 	}
 
 	emoji := "✅"

--- a/Task 2/backend/lambdas/discord/commands/admin_meal.go
+++ b/Task 2/backend/lambdas/discord/commands/admin_meal.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
+	"time"
 
 	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/client"
 	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/types"
@@ -17,15 +19,15 @@ func init() {
 // API errors come in format: "API /path returned status 400: {"error": "actual message"}"
 func extractAPIErrorMessage(err error) string {
 	errStr := err.Error()
-	
+
 	// Find the JSON part after the colon
 	colonIndex := strings.LastIndex(errStr, ": ")
 	if colonIndex == -1 {
 		return errStr
 	}
-	
+
 	jsonStr := errStr[colonIndex+2:]
-	
+
 	// Try to parse as JSON
 	var errorResp struct {
 		Error string `json:"error"`
@@ -33,9 +35,37 @@ func extractAPIErrorMessage(err error) string {
 	if json.Unmarshal([]byte(jsonStr), &errorResp) == nil && errorResp.Error != "" {
 		return errorResp.Error
 	}
-	
+
 	// Fallback to original error if parsing fails
 	return errStr
+}
+
+// validateDiscordUserID checks if the provided string is a valid Discord user ID (numeric snowflake).
+func validateDiscordUserID(userID string) bool {
+	if userID == "" {
+		return false
+	}
+	matched, _ := regexp.MatchString(`^\d+$`, userID)
+	return matched
+}
+
+// validateDateFormat checks if the provided string is in YYYY-MM-DD format.
+func validateDateFormat(date string) bool {
+	if date == "" {
+		return false
+	}
+	_, err := time.Parse("2006-01-02", date)
+	return err == nil
+}
+
+// validateMealType checks if the provided meal type is valid.
+func validateMealType(mealType string) bool {
+	return mealType == "lunch" || mealType == "snacks"
+}
+
+// validateMealStatus checks if the provided meal status is valid.
+func validateMealStatus(status string) bool {
+	return status == "YES" || status == "NO"
 }
 
 // HandleAdminMeal routes /admin-meal subcommands.
@@ -61,6 +91,12 @@ func HandleAdminMeal(data *types.CommandData, userID string) *types.InteractionR
 		if targetUserID == "" || date == "" {
 			return types.ErrorResponse("Please provide all required options: employee and date.")
 		}
+		if !validateDiscordUserID(targetUserID) {
+			return types.ErrorResponse("Invalid employee ID format. Please provide a valid Discord user ID.")
+		}
+		if !validateDateFormat(date) {
+			return types.ErrorResponse("Invalid date format. Please use YYYY-MM-DD format (e.g. 2026-03-15).")
+		}
 		return handleAdminMealView(userID, targetUserID, date)
 	case "set":
 		var targetUserID, date, mealType, status string
@@ -80,6 +116,18 @@ func HandleAdminMeal(data *types.CommandData, userID string) *types.InteractionR
 		}
 		if targetUserID == "" || date == "" || mealType == "" || status == "" {
 			return types.ErrorResponse("Please provide all required options: employee, date, meal_type, and status.")
+		}
+		if !validateDiscordUserID(targetUserID) {
+			return types.ErrorResponse("Invalid employee ID format. Please provide a valid Discord user ID.")
+		}
+		if !validateDateFormat(date) {
+			return types.ErrorResponse("Invalid date format. Please use YYYY-MM-DD format (e.g. 2026-03-15).")
+		}
+		if !validateMealType(mealType) {
+			return types.ErrorResponse("Invalid meal type. Must be 'lunch' or 'snacks'.")
+		}
+		if !validateMealStatus(status) {
+			return types.ErrorResponse("Invalid status. Must be 'YES' or 'NO'.")
 		}
 		return handleAdminMealSet(userID, targetUserID, date, mealType, status)
 	default:

--- a/Task 2/backend/lambdas/discord/commands/definitions.go
+++ b/Task 2/backend/lambdas/discord/commands/definitions.go
@@ -137,5 +137,69 @@ func Definitions() []SlashCommandDefinition {
 				},
 			},
 		},
+		{
+			Name:        "admin-meal",
+			Description: "Manage meal participation for any employee (Admin only)",
+			Options: []SlashCommandOption{
+				{
+					Name:        "view",
+					Description: "View an employee's meal participation for a specific date",
+					Type:        1, // SUB_COMMAND
+					Options: []SlashCommandOption{
+						{
+							Name:        "employee",
+							Description: "The employee to view",
+							Type:        6, // USER
+							Required:    true,
+						},
+						{
+							Name:        "date",
+							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
+							Type:        3, // STRING
+							Required:    true,
+						},
+					},
+				},
+				{
+					Name:        "set",
+					Description: "Set an employee's meal participation status",
+					Type:        1, // SUB_COMMAND
+					Options: []SlashCommandOption{
+						{
+							Name:        "employee",
+							Description: "The employee to update",
+							Type:        6, // USER
+							Required:    true,
+						},
+						{
+							Name:        "date",
+							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
+							Type:        3, // STRING
+							Required:    true,
+						},
+						{
+							Name:        "meal_type",
+							Description: "The meal to update",
+							Type:        3, // STRING
+							Required:    true,
+							Choices: []SlashCommandChoice{
+								{Name: "Lunch", Value: "lunch"},
+								{Name: "Snacks", Value: "snacks"},
+							},
+						},
+						{
+							Name:        "status",
+							Description: "YES to opt in, NO to opt out",
+							Type:        3, // STRING
+							Required:    true,
+							Choices: []SlashCommandChoice{
+								{Name: "YES — Opt in", Value: "YES"},
+								{Name: "NO — Opt out", Value: "NO"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/Task 2/backend/lambdas/set-admin-meal-status/main.go
+++ b/Task 2/backend/lambdas/set-admin-meal-status/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/config"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/service"
+)
+
+type SetAdminMealStatusRequest struct {
+	AdminDiscordID  string `json:"admin_discord_id"`
+	TargetDiscordID string `json:"target_discord_id"`
+	Date            string `json:"date"`
+	MealType        string `json:"meal_type"`
+	Status          string `json:"status"`
+}
+
+func SetAdminMealStatusHandler(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var req SetAdminMealStatusRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil ||
+		req.AdminDiscordID == "" || req.TargetDiscordID == "" ||
+		req.Date == "" || req.MealType == "" || req.Status == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]string{
+			"error": "invalid request: admin_discord_id, target_discord_id, date, meal_type, and status are required",
+		}), nil
+	}
+
+	if err := service.AdminSetMealStatus(req.AdminDiscordID, req.TargetDiscordID, req.Date, req.MealType, req.Status); err != nil {
+		var ve *service.ValidationError
+		if errors.As(err, &ve) {
+			return jsonResponse(http.StatusBadRequest, map[string]string{"error": err.Error()}), nil
+		}
+		return jsonResponse(http.StatusInternalServerError, map[string]string{"error": err.Error()}), nil
+	}
+
+	return jsonResponse(http.StatusOK, map[string]string{"message": "meal status updated successfully"}), nil
+}
+
+func jsonResponse(statusCode int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}
+
+func main() {
+	cfg := config.LoadConfig()
+	if err := database.InitDynamoDB(cfg); err != nil {
+		panic(err)
+	}
+	lambda.Start(SetAdminMealStatusHandler)
+}

--- a/Task 2/backend/lambdas/view-admin-meal-participation/main.go
+++ b/Task 2/backend/lambdas/view-admin-meal-participation/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/config"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/service"
+)
+
+type ViewAdminMealRequest struct {
+	AdminDiscordID  string `json:"admin_discord_id"`
+	TargetDiscordID string `json:"target_discord_id"`
+	Date            string `json:"date"`
+}
+
+func ViewAdminMealParticipationHandler(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var req ViewAdminMealRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil ||
+		req.AdminDiscordID == "" || req.TargetDiscordID == "" || req.Date == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]string{
+			"error": "invalid request: admin_discord_id, target_discord_id, and date are required",
+		}), nil
+	}
+
+	result, err := service.AdminGetMealView(req.AdminDiscordID, req.TargetDiscordID, req.Date)
+	if err != nil {
+		var ve *service.ValidationError
+		if errors.As(err, &ve) {
+			return jsonResponse(http.StatusBadRequest, map[string]string{"error": err.Error()}), nil
+		}
+		return jsonResponse(http.StatusInternalServerError, map[string]string{"error": err.Error()}), nil
+	}
+
+	return jsonResponse(http.StatusOK, result), nil
+}
+
+func jsonResponse(statusCode int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}
+
+func main() {
+	cfg := config.LoadConfig()
+	if err := database.InitDynamoDB(cfg); err != nil {
+		panic(err)
+	}
+	lambda.Start(ViewAdminMealParticipationHandler)
+}


### PR DESCRIPTION
Closes #44

## Dependencies

- Merge PR #62

## What does this PR do?

-  Implements functionality that enables admins to view and update individual employee meal participation for specific dates and meal types.

## Type of Change

- [x] Feature

## What was changed

- Admins can view employee meal status for a specific date
- Admins can update employee meal status for a specific date and meal type
- Discord commands for updating and viewing employee meal status by employees has been added

## How to Test

### Admin view meal participation:

via discord bot →
Use the /admin-meal view Discord slash command to view a specific employee's meal participation for a date.
Command format:
```
/admin-meal view employee:@Employee date:YYYY-MM-DD
```
Example:
```
/admin-meal view employee:@JohnDoe date:2026-03-25
```

Expected Response:
```
Meal Participation — 2026-03-25
Lunch    ✅ YES
Snacks   ✅ YES
Employee: employee_discord_id
```
via direct api call →
```
curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/meal/admin/view -H "Content-Type: application/json" -d "{\"admin_discord_id\": \"your_admin_discord_id\", \"target_discord_id\": \"employee_discord_id\", \"date\": \"2026-03-25\"}"
```
Expected Response:
```
{"date":"2026-03-25","user_id":"employee_discord_id","meals":{"lunch":"YES","snacks":"YES"}}
```
### Admin - Set Meal Status
via discord bot →
Use the /admin-meal set Discord slash command to update any employee's meal participation status.
Command format:
```
/admin-meal set employee:@Employee date:YYYY-MM-DD meal_type:Lunch/Snacks status:Yes/No
```
Example:
```
/admin-meal set employee:@JohnDoe date:2026-03-25 meal_type:Lunch status:No
```
Expected Response:
```
Admin Meal Status Updated
❌ @employee_discord_id has been opted out of Lunch on 2026-03-25.
Updated by admin: your_admin_discord_id
```
via direct api call →
```
curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/meal/admin/set -H "Content-Type: application/json" -d "{\"admin_discord_id\": \"your_admin_discord_id\", \"target_discord_id\": \"employee_discord_id\", \"date\": \"2026-03-25\", \"meal_type\": \"lunch\", \"status\": \"NO\"}"
```
Expected Response:
```
{"message":"meal status updated successfully"}
```
### Discord Server ->
```
https://discord.gg/94QjexfdQR
```

## Checklist

- [x] Admin can update the meal status of an employee
- [x] Admin can view the meal status of an employee
- [x] Discord commands have been added

