### PR TITLE
Implement Feature: Work Location and Day Status Management 

### DIFF
--- a/Task 2/backend/common/repository/meal_repository.go
+++ b/Task 2/backend/common/repository/meal_repository.go
@@ -334,3 +334,44 @@ func SetMealTypeForDate(date, mealType, adminID string) error {
 	})
 	return err
 }
+
+// GetWorkLocation returns the stored work location for a user on a given date.
+// Returns "OFFICE" if no record exists (opted in by default).
+func GetWorkLocation(userID, date string) (string, error) {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	result, err := db.GetItem(&dynamodb.GetItemInput{
+		TableName: aws.String(table),
+		Key: map[string]*dynamodb.AttributeValue{
+			"PK": {S: aws.String("DAY#" + date)},
+			"SK": {S: aws.String("LOCATION#USER#" + userID)},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	if result.Item == nil {
+		return "OFFICE", nil
+	}
+	if v, ok := result.Item["location"]; ok && v.S != nil {
+		return *v.S, nil
+	}
+	return "OFFICE", nil
+}
+
+// SetWorkLocation stores a user's work location for a given date.
+func SetWorkLocation(userID, date, location string) error {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	_, err := db.PutItem(&dynamodb.PutItemInput{
+		TableName: aws.String(table),
+		Item: map[string]*dynamodb.AttributeValue{
+			"PK":       {S: aws.String("DAY#" + date)},
+			"SK":       {S: aws.String("LOCATION#USER#" + userID)},
+			"location": {S: aws.String(location)},
+		},
+	})
+	return err
+}

--- a/Task 2/backend/common/repository/meal_repository.go
+++ b/Task 2/backend/common/repository/meal_repository.go
@@ -360,6 +360,33 @@ func GetWorkLocation(userID, date string) (string, error) {
 	return "OFFICE", nil
 }
 
+// GetWorkLocationCountsForDate returns how many users have each work location explicitly set for a date.
+// Result is a map of location ("OFFICE"/"WFH") → count of explicit records.
+func GetWorkLocationCountsForDate(date string) (map[string]int, error) {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	out, err := db.Query(&dynamodb.QueryInput{
+		TableName:              aws.String(table),
+		KeyConditionExpression: aws.String("PK = :pk AND begins_with(SK, :prefix)"),
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":pk":     {S: aws.String("DAY#" + date)},
+			":prefix": {S: aws.String("LOCATION#USER#")},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	counts := map[string]int{}
+	for _, item := range out.Items {
+		if v, ok := item["location"]; ok && v.S != nil {
+			counts[*v.S]++
+		}
+	}
+	return counts, nil
+}
+
 // SetWorkLocation stores a user's work location for a given date.
 func SetWorkLocation(userID, date, location string) error {
 	db := database.GetDBClient()

--- a/Task 2/backend/common/repository/meal_repository.go
+++ b/Task 2/backend/common/repository/meal_repository.go
@@ -402,3 +402,90 @@ func SetWorkLocation(userID, date, location string) error {
 	})
 	return err
 }
+
+// DayStatus holds the administrative status for a specific day.
+type DayStatus struct {
+	Type  string // GOVERNMENT_HOLIDAY | OFFICE_CLOSED | SPECIAL_EVENT
+	Note  string // populated for SPECIAL_EVENT
+	SetBy string // admin Discord ID
+}
+
+// SetDayStatus stores the administrative status for a given date.
+func SetDayStatus(date, statusType, note, adminID string) error {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	item := map[string]*dynamodb.AttributeValue{
+		"PK":    {S: aws.String("DAY#" + date)},
+		"SK":    {S: aws.String("STATUS")},
+		"type":  {S: aws.String(statusType)},
+		"setBy": {S: aws.String(adminID)},
+	}
+	if note != "" {
+		item["note"] = &dynamodb.AttributeValue{S: aws.String(note)}
+	}
+
+	_, err := db.PutItem(&dynamodb.PutItemInput{
+		TableName: aws.String(table),
+		Item:      item,
+	})
+	return err
+}
+
+// GetDayStatus returns the administrative status for a given date.
+// Returns nil if no status has been set.
+func GetDayStatus(date string) (*DayStatus, error) {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	result, err := db.GetItem(&dynamodb.GetItemInput{
+		TableName: aws.String(table),
+		Key: map[string]*dynamodb.AttributeValue{
+			"PK": {S: aws.String("DAY#" + date)},
+			"SK": {S: aws.String("STATUS")},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if result.Item == nil {
+		return nil, nil
+	}
+
+	ds := &DayStatus{}
+	if v, ok := result.Item["type"]; ok && v.S != nil {
+		ds.Type = *v.S
+	}
+	if v, ok := result.Item["note"]; ok && v.S != nil {
+		ds.Note = *v.S
+	}
+	if v, ok := result.Item["setBy"]; ok && v.S != nil {
+		ds.SetBy = *v.S
+	}
+	return ds, nil
+}
+
+// GetAllUserIDs returns Discord IDs for all registered users.
+func GetAllUserIDs() ([]string, error) {
+	db := database.GetDBClient()
+	table := database.GetTableName()
+
+	var users []string
+	err := db.ScanPages(&dynamodb.ScanInput{
+		TableName:        aws.String(table),
+		FilterExpression: aws.String("SK = :meta AND begins_with(PK, :user)"),
+		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
+			":meta": {S: aws.String("META")},
+			":user": {S: aws.String("USER#")},
+		},
+		ProjectionExpression: aws.String("PK"),
+	}, func(page *dynamodb.ScanOutput, _ bool) bool {
+		for _, item := range page.Items {
+			if v, ok := item["PK"]; ok && v.S != nil {
+				users = append(users, strings.TrimPrefix(*v.S, "USER#"))
+			}
+		}
+		return true
+	})
+	return users, err
+}

--- a/Task 2/backend/common/service/meal_service.go
+++ b/Task 2/backend/common/service/meal_service.go
@@ -493,3 +493,95 @@ func SetWorkLocationForDate(discordID, date, location string) error {
 
 	return repository.SetWorkLocation(discordID, date, location)
 }
+
+// Day status type constants.
+const (
+	DayStatusGovernmentHoliday = "GOVERNMENT_HOLIDAY"
+	DayStatusOfficeClosed      = "OFFICE_CLOSED"
+	DayStatusSpecialEvent      = "SPECIAL_EVENT"
+)
+
+// DayStatusResponse is returned when viewing the status of a specific day.
+type DayStatusResponse struct {
+	Date  string `json:"date"`
+	Type  string `json:"type"`
+	Note  string `json:"note,omitempty"`
+	SetBy string `json:"set_by,omitempty"`
+}
+
+// AdminSetDayStatus sets the administrative status for a specific day. Only admins may call this.
+// GOVERNMENT_HOLIDAY and SPECIAL_EVENT only update the day status marker.
+// OFFICE_CLOSED additionally opts out all registered users from every meal on that date.
+// A non-empty note is required for SPECIAL_EVENT.
+func AdminSetDayStatus(adminID, date, statusType, note string) error {
+	role, _, err := repository.GetUserRole(adminID)
+	if err != nil {
+		return err
+	}
+	if role != "ADMIN" {
+		return &ValidationError{"access denied: only admins can perform this action"}
+	}
+
+	switch statusType {
+	case DayStatusGovernmentHoliday, DayStatusOfficeClosed, DayStatusSpecialEvent:
+		// valid
+	default:
+		return &ValidationError{fmt.Sprintf("invalid status type '%s': must be GOVERNMENT_HOLIDAY, OFFICE_CLOSED, or SPECIAL_EVENT", statusType)}
+	}
+
+	if statusType == DayStatusSpecialEvent && strings.TrimSpace(note) == "" {
+		return &ValidationError{"a note is required for SPECIAL_EVENT day status"}
+	}
+
+	if statusType == DayStatusOfficeClosed {
+		if err := optOutAllMealsForDate(date); err != nil {
+			return err
+		}
+	}
+
+	return repository.SetDayStatus(date, statusType, note, adminID)
+}
+
+// optOutAllMealsForDate sets all meal participation records to NO for every registered user on the given date.
+func optOutAllMealsForDate(date string) error {
+	allUsers, err := repository.GetAllUserIDs()
+	if err != nil {
+		return err
+	}
+
+	mealTypes, err := GetMealTypesForDate(date)
+	if err != nil {
+		return err
+	}
+
+	for _, userID := range allUsers {
+		_, teamID, err := repository.GetUserRole(userID)
+		if err != nil {
+			continue // skip users without a valid role/team record
+		}
+		for _, mt := range mealTypes {
+			if err := repository.SetMealParticipation(userID, date, mt, "NO", teamID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// GetDayStatusForDate returns the administrative status for a given date.
+// Returns Type="NORMAL" when no status has been set.
+func GetDayStatusForDate(date string) (*DayStatusResponse, error) {
+	ds, err := repository.GetDayStatus(date)
+	if err != nil {
+		return nil, err
+	}
+	if ds == nil {
+		return &DayStatusResponse{Date: date, Type: "NORMAL"}, nil
+	}
+	return &DayStatusResponse{
+		Date:  date,
+		Type:  ds.Type,
+		Note:  ds.Note,
+		SetBy: ds.SetBy,
+	}, nil
+}

--- a/Task 2/backend/common/service/meal_service.go
+++ b/Task 2/backend/common/service/meal_service.go
@@ -403,3 +403,73 @@ func isPastCutoff(date string) (bool, error) {
 	// Day after tomorrow or further: not locked
 	return false, nil
 }
+
+// WorkLocationResponse is returned when viewing a user's work location for a date.
+type WorkLocationResponse struct {
+	Date     string `json:"date"`
+	UserID   string `json:"user_id"`
+	Location string `json:"location"`
+}
+
+// GetWorkLocationForDate returns a user's work location for a given date.
+// Defaults to OFFICE if no record exists.
+func GetWorkLocationForDate(discordID, date string) (*WorkLocationResponse, error) {
+	if err := repository.EnsureUserExists(discordID); err != nil {
+		return nil, err
+	}
+
+	location, err := repository.GetWorkLocation(discordID, date)
+	if err != nil {
+		return nil, err
+	}
+
+	return &WorkLocationResponse{
+		Date:     date,
+		UserID:   discordID,
+		Location: location,
+	}, nil
+}
+
+// SetWorkLocationForDate updates a user's work location for a given date.
+// Switching to WFH opts out all meals; switching to OFFICE opts all meals back in.
+func SetWorkLocationForDate(discordID, date, location string) error {
+	if err := repository.EnsureUserExists(discordID); err != nil {
+		return err
+	}
+
+	_, teamID, err := repository.GetUserRole(discordID)
+	if err != nil {
+		return err
+	}
+
+	location = strings.ToUpper(location)
+	if location != "OFFICE" && location != "WFH" {
+		return &ValidationError{fmt.Sprintf("invalid location '%s': must be 'OFFICE' or 'WFH'", location)}
+	}
+
+	locked, err := isPastCutoff(date)
+	if err != nil {
+		return &ValidationError{err.Error()}
+	}
+	if locked {
+		return &ValidationError{"the cutoff time (9pm) has passed — work location can no longer be updated for this date"}
+	}
+
+	mealTypes, err := GetMealTypesForDate(date)
+	if err != nil {
+		return err
+	}
+
+	status := "YES"
+	if location == "WFH" {
+		status = "NO"
+	}
+
+	for _, mt := range mealTypes {
+		if err := repository.SetMealParticipation(discordID, date, mt, status, teamID); err != nil {
+			return err
+		}
+	}
+
+	return repository.SetWorkLocation(discordID, date, location)
+}

--- a/Task 2/backend/common/service/meal_service.go
+++ b/Task 2/backend/common/service/meal_service.go
@@ -321,9 +321,15 @@ type HeadcountEntry struct {
 	No  int `json:"no"`
 }
 
+type WorkLocationSummary struct {
+	Office int `json:"office"`
+	WFH    int `json:"wfh"`
+}
+
 type HeadcountSummaryResponse struct {
-	Date    string                    `json:"date"`
-	Summary map[string]HeadcountEntry `json:"summary"`
+	Date         string                    `json:"date"`
+	WorkLocation WorkLocationSummary       `json:"work_location"`
+	Summary      map[string]HeadcountEntry `json:"summary"`
 }
 
 // AdminGetHeadcountSummary returns per-meal-type headcount for a given date.
@@ -365,9 +371,23 @@ func AdminGetHeadcountSummary(adminID, date string) (*HeadcountSummaryResponse, 
 		}
 	}
 
+	locationCounts, err := repository.GetWorkLocationCountsForDate(date)
+	if err != nil {
+		return nil, err
+	}
+	// Users with no location record are implicitly OFFICE.
+	explicitWFH := locationCounts["WFH"]
+	explicitOffice := locationCounts["OFFICE"]
+	workLocation := WorkLocationSummary{
+		Office: totalUsers - explicitWFH,
+		WFH:    explicitWFH,
+	}
+	_ = explicitOffice // counted implicitly above
+
 	return &HeadcountSummaryResponse{
-		Date:    date,
-		Summary: summary,
+		Date:         date,
+		WorkLocation: workLocation,
+		Summary:      summary,
 	}, nil
 }
 

--- a/Task 2/backend/lambdas/discord/commands/admin_meal.go
+++ b/Task 2/backend/lambdas/discord/commands/admin_meal.go
@@ -169,9 +169,15 @@ type headcountEntry struct {
 	No  int `json:"no"`
 }
 
+type workLocationSummary struct {
+	Office int `json:"office"`
+	WFH    int `json:"wfh"`
+}
+
 type adminHeadcountResponse struct {
-	Date    string                    `json:"date"`
-	Summary map[string]headcountEntry `json:"summary"`
+	Date         string                    `json:"date"`
+	WorkLocation workLocationSummary       `json:"work_location"`
+	Summary      map[string]headcountEntry `json:"summary"`
 }
 
 func handleAdminHeadcount(adminID, date string) *types.InteractionResponse {
@@ -184,13 +190,25 @@ func handleAdminHeadcount(adminID, date string) *types.InteractionResponse {
 		return types.ErrorResponse("Failed to fetch headcount: " + err.Error())
 	}
 
+	fields := []types.EmbedField{
+		{
+			Name:   "Work Location",
+			Value:  fmt.Sprintf("🏢 Office: **%d**  |  🏠 WFH: **%d**", result.WorkLocation.Office, result.WorkLocation.WFH),
+			Inline: false,
+		},
+		{
+			Name:   "​",
+			Value:  "**Meal Participation**",
+			Inline: false,
+		},
+	}
+
 	mealTypeKeys := make([]string, 0, len(result.Summary))
 	for mt := range result.Summary {
 		mealTypeKeys = append(mealTypeKeys, mt)
 	}
 	sort.Strings(mealTypeKeys)
 
-	fields := make([]types.EmbedField, 0, len(result.Summary))
 	for _, mt := range mealTypeKeys {
 		entry := result.Summary[mt]
 		fields = append(fields, types.EmbedField{

--- a/Task 2/backend/lambdas/discord/commands/day_status.go
+++ b/Task 2/backend/lambdas/discord/commands/day_status.go
@@ -1,0 +1,160 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/client"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/types"
+)
+
+func init() {
+	Register("day-status", HandleDayStatus)
+}
+
+// HandleDayStatus routes /day-status subcommands.
+func HandleDayStatus(data *types.CommandData, userID string) *types.InteractionResponse {
+	if len(data.Options) == 0 {
+		return types.ErrorResponse("Please provide a subcommand. Usage: `/day-status set` or `/day-status view`")
+	}
+
+	sub := data.Options[0]
+	switch sub.Name {
+	case "set":
+		var date, statusType, note string
+		for _, opt := range sub.Options {
+			if v, ok := opt.Value.(string); ok {
+				switch opt.Name {
+				case "date":
+					date = v
+				case "type":
+					statusType = v
+				case "note":
+					note = v
+				}
+			}
+		}
+		if date == "" || statusType == "" {
+			return types.ErrorResponse("Please provide all required options: date and type.")
+		}
+		return handleDayStatusSet(userID, date, statusType, note)
+	case "view":
+		var date string
+		for _, opt := range sub.Options {
+			if v, ok := opt.Value.(string); ok && opt.Name == "date" {
+				date = v
+			}
+		}
+		if date == "" {
+			return types.ErrorResponse("Please provide the required option: date.")
+		}
+		return handleDayStatusView(date)
+	default:
+		return types.ErrorResponse(fmt.Sprintf("Unknown subcommand: `%s`", sub.Name))
+	}
+}
+
+type dayStatusSetRequest struct {
+	AdminDiscordID string `json:"admin_discord_id"`
+	Date           string `json:"date"`
+	StatusType     string `json:"status_type"`
+	Note           string `json:"note"`
+}
+
+func handleDayStatusSet(adminID, date, statusType, note string) *types.InteractionResponse {
+	err := client.Post("/day/status/set", dayStatusSetRequest{
+		AdminDiscordID: adminID,
+		Date:           date,
+		StatusType:     statusType,
+		Note:           note,
+	}, nil)
+	if err != nil {
+		return types.ErrorResponse("Failed to set day status: " + err.Error())
+	}
+
+	var emoji, label string
+	switch statusType {
+	case "GOVERNMENT_HOLIDAY":
+		emoji = "🏛️"
+		label = "Government Holiday"
+	case "OFFICE_CLOSED":
+		emoji = "🔒"
+		label = "Office Closed"
+	case "SPECIAL_EVENT":
+		emoji = "🎉"
+		label = "Special Event"
+	default:
+		emoji = "📅"
+		label = statusType
+	}
+
+	description := fmt.Sprintf("%s **%s** has been marked as **%s**.", emoji, date, label)
+	if statusType == "OFFICE_CLOSED" {
+		description += "\nAll meals for this day have been automatically opted out for all employees."
+	}
+	if note != "" {
+		description += fmt.Sprintf("\n📝 Note: %s", note)
+	}
+
+	return types.EmbedResponse(types.Embed{
+		Title:       "Day Status Updated",
+		Description: description,
+		Color:       types.ColorSuccess,
+		Footer:      &types.EmbedFooter{Text: "Set by admin: " + adminID},
+	})
+}
+
+type dayStatusViewRequest struct {
+	Date string `json:"date"`
+}
+
+type dayStatusViewResponse struct {
+	Date  string `json:"date"`
+	Type  string `json:"type"`
+	Note  string `json:"note"`
+	SetBy string `json:"set_by"`
+}
+
+func handleDayStatusView(date string) *types.InteractionResponse {
+	var result dayStatusViewResponse
+	err := client.Post("/day/status/view", dayStatusViewRequest{Date: date}, &result)
+	if err != nil {
+		return types.ErrorResponse("Failed to fetch day status: " + err.Error())
+	}
+
+	var emoji, label string
+	switch result.Type {
+	case "GOVERNMENT_HOLIDAY":
+		emoji = "🏛️"
+		label = "Government Holiday"
+	case "OFFICE_CLOSED":
+		emoji = "🔒"
+		label = "Office Closed"
+	case "SPECIAL_EVENT":
+		emoji = "🎉"
+		label = "Special Event"
+	default:
+		emoji = "✅"
+		label = "Normal Working Day"
+	}
+
+	fields := []types.EmbedField{
+		{Name: "Status", Value: fmt.Sprintf("%s %s", emoji, label), Inline: true},
+	}
+	if result.Note != "" {
+		fields = append(fields, types.EmbedField{Name: "Note", Value: result.Note, Inline: false})
+	}
+	if result.SetBy != "" {
+		fields = append(fields, types.EmbedField{Name: "Set by", Value: "<@" + result.SetBy + ">", Inline: true})
+	}
+
+	color := types.ColorInfo
+	if result.Type == "OFFICE_CLOSED" || result.Type == "GOVERNMENT_HOLIDAY" {
+		color = types.ColorError
+	}
+
+	return types.EmbedResponse(types.Embed{
+		Title:  "Day Status — " + result.Date,
+		Color:  color,
+		Fields: fields,
+	})
+}

--- a/Task 2/backend/lambdas/discord/commands/definitions.go
+++ b/Task 2/backend/lambdas/discord/commands/definitions.go
@@ -207,6 +207,48 @@ func Definitions() []SlashCommandDefinition {
 			},
 		},
 		{
+			Name:        "work-location",
+			Description: "Manage your work location (Office/WFH)",
+			Options: []SlashCommandOption{
+				{
+					Name:        "view",
+					Description: "View your work location for a specific date",
+					Type:        1, // SUB_COMMAND
+					Options: []SlashCommandOption{
+						{
+							Name:        "date",
+							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
+							Type:        3, // STRING
+							Required:    true,
+						},
+					},
+				},
+				{
+					Name:        "set",
+					Description: "Set your work location for a specific date (before 9pm cutoff)",
+					Type:        1, // SUB_COMMAND
+					Options: []SlashCommandOption{
+						{
+							Name:        "date",
+							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
+							Type:        3, // STRING
+							Required:    true,
+						},
+						{
+							Name:        "location",
+							Description: "Your work location",
+							Type:        3, // STRING
+							Required:    true,
+							Choices: []SlashCommandChoice{
+								{Name: "🏢 Office", Value: "OFFICE"},
+								{Name: "🏠 Work from Home", Value: "WFH"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			Name:        "meal-type",
 			Description: "Manage meal types for a specific date (Admin only)",
 			Options: []SlashCommandOption{

--- a/Task 2/backend/lambdas/discord/commands/definitions.go
+++ b/Task 2/backend/lambdas/discord/commands/definitions.go
@@ -286,5 +286,54 @@ func Definitions() []SlashCommandDefinition {
 				},
 			},
 		},
+		{
+			Name:        "day-status",
+			Description: "Manage the status of a specific day (Admin only)",
+			Options: []SlashCommandOption{
+				{
+					Name:        "set",
+					Description: "Set the status for a specific day",
+					Type:        1, // SUB_COMMAND
+					Options: []SlashCommandOption{
+						{
+							Name:        "date",
+							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
+							Type:        3, // STRING
+							Required:    true,
+						},
+						{
+							Name:        "type",
+							Description: "Type of day status",
+							Type:        3, // STRING
+							Required:    true,
+							Choices: []SlashCommandChoice{
+								{Name: "🏛️ Government Holiday", Value: "GOVERNMENT_HOLIDAY"},
+								{Name: "🔒 Office Closed", Value: "OFFICE_CLOSED"},
+								{Name: "🎉 Special Event", Value: "SPECIAL_EVENT"},
+							},
+						},
+						{
+							Name:        "note",
+							Description: "Additional note (required for Special Event)",
+							Type:        3, // STRING
+							Required:    false,
+						},
+					},
+				},
+				{
+					Name:        "view",
+					Description: "View the status of a specific day",
+					Type:        1, // SUB_COMMAND
+					Options: []SlashCommandOption{
+						{
+							Name:        "date",
+							Description: "Date in YYYY-MM-DD format (e.g. 2026-03-15)",
+							Type:        3, // STRING
+							Required:    true,
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/Task 2/backend/lambdas/discord/commands/work_location.go
+++ b/Task 2/backend/lambdas/discord/commands/work_location.go
@@ -1,0 +1,119 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/client"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/lambdas/discord/types"
+)
+
+func init() {
+	Register("work-location", HandleWorkLocation)
+}
+
+// HandleWorkLocation routes /work-location subcommands.
+func HandleWorkLocation(data *types.CommandData, userID string) *types.InteractionResponse {
+	if len(data.Options) == 0 {
+		return types.ErrorResponse("Please provide a subcommand. Usage: `/work-location view` or `/work-location set`")
+	}
+
+	sub := data.Options[0]
+	switch sub.Name {
+	case "view":
+		var date string
+		for _, opt := range sub.Options {
+			if v, ok := opt.Value.(string); ok && opt.Name == "date" {
+				date = v
+			}
+		}
+		if date == "" {
+			return types.ErrorResponse("Please provide the required option: date.")
+		}
+		return handleWorkLocationView(userID, date)
+	case "set":
+		var date, location string
+		for _, opt := range sub.Options {
+			if v, ok := opt.Value.(string); ok {
+				switch opt.Name {
+				case "date":
+					date = v
+				case "location":
+					location = v
+				}
+			}
+		}
+		if date == "" || location == "" {
+			return types.ErrorResponse("Please provide all required options: date and location.")
+		}
+		return handleWorkLocationSet(userID, date, location)
+	default:
+		return types.ErrorResponse(fmt.Sprintf("Unknown subcommand: `%s`", sub.Name))
+	}
+}
+
+type workLocationViewRequest struct {
+	DiscordID string `json:"discord_id"`
+	Date      string `json:"date"`
+}
+
+type workLocationViewResponse struct {
+	Date     string `json:"date"`
+	UserID   string `json:"user_id"`
+	Location string `json:"location"`
+}
+
+func handleWorkLocationView(userID, date string) *types.InteractionResponse {
+	var result workLocationViewResponse
+	err := client.Post("/work-location/view", workLocationViewRequest{
+		DiscordID: userID,
+		Date:      date,
+	}, &result)
+	if err != nil {
+		return types.ErrorResponse("Failed to fetch work location: " + err.Error())
+	}
+
+	emoji := "🏢"
+	label := "Office"
+	if result.Location == "WFH" {
+		emoji = "🏠"
+		label = "Work from Home"
+	}
+
+	return types.EmbedResponse(types.Embed{
+		Title:       "Work Location — " + result.Date,
+		Description: fmt.Sprintf("%s **%s**", emoji, label),
+		Color:       types.ColorInfo,
+	})
+}
+
+type workLocationSetRequest struct {
+	DiscordID string `json:"discord_id"`
+	Date      string `json:"date"`
+	Location  string `json:"location"`
+}
+
+func handleWorkLocationSet(userID, date, location string) *types.InteractionResponse {
+	err := client.Post("/work-location/set", workLocationSetRequest{
+		DiscordID: userID,
+		Date:      date,
+		Location:  location,
+	}, nil)
+	if err != nil {
+		return types.ErrorResponse("Failed to update work location: " + err.Error())
+	}
+
+	emoji := "🏢"
+	label := "Office"
+	mealNote := "Your meals have been opted **in**."
+	if location == "WFH" {
+		emoji = "🏠"
+		label = "Work from Home"
+		mealNote = "Your meals have been opted **out** for this date."
+	}
+
+	return types.EmbedResponse(types.Embed{
+		Title:       "Work Location Updated",
+		Description: fmt.Sprintf("%s Your work location on **%s** has been set to **%s**.\n%s", emoji, date, label, mealNote),
+		Color:       types.ColorSuccess,
+	})
+}

--- a/Task 2/backend/lambdas/set-day-status/main.go
+++ b/Task 2/backend/lambdas/set-day-status/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/config"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/service"
+)
+
+type SetDayStatusRequest struct {
+	AdminDiscordID string `json:"admin_discord_id"`
+	Date           string `json:"date"`
+	StatusType     string `json:"status_type"`
+	Note           string `json:"note"`
+}
+
+func SetDayStatusHandler(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var req SetDayStatusRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil ||
+		req.AdminDiscordID == "" || req.Date == "" || req.StatusType == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]string{
+			"error": "invalid request: admin_discord_id, date, and status_type are required",
+		}), nil
+	}
+
+	if err := service.AdminSetDayStatus(req.AdminDiscordID, req.Date, req.StatusType, req.Note); err != nil {
+		var ve *service.ValidationError
+		if errors.As(err, &ve) {
+			return jsonResponse(http.StatusBadRequest, map[string]string{"error": err.Error()}), nil
+		}
+		return jsonResponse(http.StatusInternalServerError, map[string]string{"error": err.Error()}), nil
+	}
+
+	return jsonResponse(http.StatusOK, map[string]string{"message": "day status set successfully"}), nil
+}
+
+func jsonResponse(statusCode int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}
+
+func main() {
+	cfg := config.LoadConfig()
+	if err := database.InitDynamoDB(cfg); err != nil {
+		panic(err)
+	}
+	lambda.Start(SetDayStatusHandler)
+}

--- a/Task 2/backend/lambdas/set-work-location/main.go
+++ b/Task 2/backend/lambdas/set-work-location/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/config"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/service"
+)
+
+type SetWorkLocationRequest struct {
+	DiscordID string `json:"discord_id"`
+	Date      string `json:"date"`
+	Location  string `json:"location"`
+}
+
+func SetWorkLocationHandler(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var req SetWorkLocationRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil ||
+		req.DiscordID == "" || req.Date == "" || req.Location == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]string{
+			"error": "invalid request: discord_id, date, and location are required",
+		}), nil
+	}
+
+	err := service.SetWorkLocationForDate(req.DiscordID, req.Date, req.Location)
+	if err != nil {
+		var ve *service.ValidationError
+		if errors.As(err, &ve) {
+			return jsonResponse(http.StatusBadRequest, map[string]string{"error": err.Error()}), nil
+		}
+		return jsonResponse(http.StatusInternalServerError, map[string]string{"error": err.Error()}), nil
+	}
+
+	return jsonResponse(http.StatusOK, map[string]string{"message": "work location updated successfully"}), nil
+}
+
+func jsonResponse(statusCode int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}
+
+func main() {
+	cfg := config.LoadConfig()
+	if err := database.InitDynamoDB(cfg); err != nil {
+		panic(err)
+	}
+	lambda.Start(SetWorkLocationHandler)
+}

--- a/Task 2/backend/lambdas/view-day-status/main.go
+++ b/Task 2/backend/lambdas/view-day-status/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/config"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/service"
+)
+
+type ViewDayStatusRequest struct {
+	Date string `json:"date"`
+}
+
+func ViewDayStatusHandler(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var req ViewDayStatusRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil || req.Date == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]string{
+			"error": "invalid request: date is required",
+		}), nil
+	}
+
+	result, err := service.GetDayStatusForDate(req.Date)
+	if err != nil {
+		return jsonResponse(http.StatusInternalServerError, map[string]string{"error": err.Error()}), nil
+	}
+
+	return jsonResponse(http.StatusOK, result), nil
+}
+
+func jsonResponse(statusCode int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}
+
+func main() {
+	cfg := config.LoadConfig()
+	if err := database.InitDynamoDB(cfg); err != nil {
+		panic(err)
+	}
+	lambda.Start(ViewDayStatusHandler)
+}

--- a/Task 2/backend/lambdas/view-work-location/main.go
+++ b/Task 2/backend/lambdas/view-work-location/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/config"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/database"
+	"github.com/samin-craftsmen/meal-headcount-planner-backend/common/service"
+)
+
+type ViewWorkLocationRequest struct {
+	DiscordID string `json:"discord_id"`
+	Date      string `json:"date"`
+}
+
+func ViewWorkLocationHandler(request events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {
+	var req ViewWorkLocationRequest
+	if err := json.Unmarshal([]byte(request.Body), &req); err != nil ||
+		req.DiscordID == "" || req.Date == "" {
+		return jsonResponse(http.StatusBadRequest, map[string]string{
+			"error": "invalid request: discord_id and date are required",
+		}), nil
+	}
+
+	result, err := service.GetWorkLocationForDate(req.DiscordID, req.Date)
+	if err != nil {
+		return jsonResponse(http.StatusInternalServerError, map[string]string{"error": err.Error()}), nil
+	}
+
+	return jsonResponse(http.StatusOK, result), nil
+}
+
+func jsonResponse(statusCode int, body any) events.APIGatewayV2HTTPResponse {
+	b, _ := json.Marshal(body)
+	return events.APIGatewayV2HTTPResponse{
+		StatusCode: statusCode,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       string(b),
+	}
+}
+
+func main() {
+	cfg := config.LoadConfig()
+	if err := database.InitDynamoDB(cfg); err != nil {
+		panic(err)
+	}
+	lambda.Start(ViewWorkLocationHandler)
+}


### PR DESCRIPTION
Closes #46
## Dependencies

- Merge PR #67

## What does this PR do?

Implements functionality:
- Employees can update their work location status
- Admins can change the status of a day

## Type of Change

- [x] Feature

## What was changed

- Employees can update their work location status
- Admins can change the status of a day

## How to Test

### Admin - Set Day Status:
via discord bot →
Use the /day-status set Discord slash command to mark a date as a holiday, office closure, or special event (Admin only).
Command format:
```
/day-status set date:YYYY-MM-DD type:GOVERNMENT_HOLIDAY/OFFICE_CLOSED/SPECIAL_EVENT note:Optional note
```
Example:
```
/day-status set date:2026-03-25 type:GOVERNMENT_HOLIDAY note:Holi
```
Expected Response:
```
Day Status Updated
🏛️ 2026-03-25 has been marked as Government Holiday.
📝 Note: Holi
Set by admin: your_admin_discord_id
```
via direct api call →
```
curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/day/status/set -H "Content-Type: application/json" -d "{\"admin_discord_id\": \"your_admin_discord_id\", \"date\": \"2026-03-25\", \"status_type\": \"GOVERNMENT_HOLIDAY\", \"note\": \"Holi\"}"
```
Expected Response:
```
{"message":"day status set successfully"}
```

### Admin - View Day Status

via discord bot →
Use the /day-status view Discord slash command to check the status of any date. Available to everyone — no admin role required.
Command format:
```
/day-status view date:YYYY-MM-DD
```
Example:
```
/day-status view date:2026-03-25
```
Expected Response:
```
Day Status — 2026-03-25
Status    🏛️ Government Holiday
Note      Holi
Set by    @your_admin_discord_id
```
If no special status has been set, the response will show ✅ Normal Working Day.

via direct api call →
```
curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/day/status/view -H "Content-Type: application/json" -d "{\"date\": \"2026-03-25\"}"
```
Expected Response (when a status is set):
```
{"date":"2026-03-25","type":"GOVERNMENT_HOLIDAY","note":"Holi","set_by":"your_admin_discord_id"}
```

### Employee - Set Work Location

via discord bot →
Use the /work-location set Discord slash command to set your work location for a specific date (before the 9pm cutoff). Setting WFH automatically opts you out of all meals for that date.
Command format:
```
/work-location set date:YYYY-MM-DD location:Office/Work from Home
```
Example:
```
/work-location set date:2026-03-25 location:Work from Home
```
Expected Response:
```
Work Location Updated
🏠 Your work location on 2026-03-25 has been set to Work from Home.
Your meals have been opted out for this date.
```
via direct api call →
```
curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/work-location/set -H "Content-Type: application/json" -d "{\"discord_id\": \"your_discord_id\", \"date\": \"2026-03-25\", \"location\": \"WFH\"}"
```
Expected Response:
```
{"message":"work location updated successfully"}
```

### Employee - View Work Location

via discord bot →
Use the /work-location view Discord slash command to check your recorded work location for a specific date.
Command format:
```
/work-location view date:YYYY-MM-DD
```
Example:
```
/work-location view date:2026-03-25
```
Expected Response:
```
Work Location — 2026-03-25
🏠 Work from Home
```
via direct api call →
```
curl -X POST https://pr807w8a23.execute-api.ap-south-1.amazonaws.com/default/work-location/view -H "Content-Type: application/json" -d "{\"discord_id\": \"your_discord_id\", \"date\": \"2026-03-25\"}"
```
Expected Response:
```
{"date":"2026-03-25","user_id":"your_discord_id","location":"WFH"}
```
### DISCORD SERVER →
```
https://discord.gg/94QjexfdQR
```
## Checklist

- [x] Employees can update their work location status
- [x] Admin can update the day status for a specific date 
- [x] Discord commands have been added

